### PR TITLE
fix: derive parent-aware default name for Graph nodes (#13)

### DIFF
--- a/docs/lessons/2026-04-26-graph-default-name.md
+++ b/docs/lessons/2026-04-26-graph-default-name.md
@@ -1,0 +1,41 @@
+# Graph default name collided across siblings
+
+**Issue:** [krill-oss#13](https://github.com/bsautner/krill-oss/issues/13)
+**Root cause category:** API design — colliding default value
+**Module:** `krill-sdk`, `krill-mcp`
+
+## What happened
+
+`GraphMetaData(name = "Data Graph", …)` made every Graph node created without
+an explicit `name` indistinguishable from its siblings. A real swarm
+(`pi-krill-05`) accumulated three Graphs all named `"Data Graph"` under
+`nitrite`, `pH`, and `nitrate` DataPoints. Other metadata classes default to
+`this::class.simpleName!!` (e.g. `FilterMetaData`, `TriggerMetaData`), which
+gave them per-subtype names — Graph has no subtypes, so the literal default
+was the only thing reaching the wire.
+
+## Fix
+
+1. `GraphMetaData.name` defaults to `""` instead of the colliding literal.
+2. `Node.name()` falls back to `"Graph"` when the meta name is empty (matches
+   the `Camera` / `Backup` `.ifEmpty { … }` pattern).
+3. `KrillNodeTypes` Graph default meta has `name = ""` so the registry no
+   longer hands out the colliding literal either.
+4. `CreateNodeTool` derives `"<parent DataPoint name> graph"` from the
+   verified parent when the caller did not supply a `name`. Parents always
+   exist at create time (the tool already fetches them for validation), so
+   this is free.
+
+## Prevention
+
+- Default values that collide across siblings are a smell — either they
+  should be derived from local context (parent, position) or removed in
+  favour of a non-defaulted parameter so the compiler points at every
+  call site.
+- When adding a new node-type metadata, prefer one of: `name = ""` with a
+  display-time fallback (UI gets to decide), `name = this::class.simpleName!!`
+  for types with multiple subtypes, or no default at all if the class needs a
+  caller-supplied identity.
+- The MCP `defaultMeta` table in `KrillNodeTypes.kt` mirrors the SDK
+  defaults; keep them in sync or the MCP tool path will reintroduce the
+  exact literal the SDK just removed.

--- a/krill-mcp/krill-mcp-service/src/main/kotlin/krill/zone/mcp/krill/KrillNodeTypes.kt
+++ b/krill-mcp/krill-mcp-service/src/main/kotlin/krill/zone/mcp/krill/KrillNodeTypes.kt
@@ -307,7 +307,7 @@ object KrillNodeTypes {
             metaFqn = "krill.zone.shared.krillapp.datapoint.graph.GraphMetaData",
             defaultMeta = meta(
                 "krill.zone.shared.krillapp.datapoint.graph.GraphMetaData",
-                "name" to JsonPrimitive("Data Graph"),
+                "name" to JsonPrimitive(""),
                 "sources" to nodeIdentityArray(),
                 "targets" to nodeIdentityArray(),
                 "timeRange" to JsonPrimitive("HOUR"),
@@ -318,7 +318,9 @@ object KrillNodeTypes {
             description = "Renders historical DataPoint values as a graph over `meta.timeRange`.",
             validParentTypes = listOf("KrillApp.DataPoint"),
             validChildTypes = emptyList(),
-            notes = "`timeRange` ∈ {NONE, HOUR, DAY, WEEK, MONTH, YEAR}. Add the parent DataPoint to `sources`.",
+            notes = "`timeRange` ∈ {NONE, HOUR, DAY, WEEK, MONTH, YEAR}. Add the parent DataPoint to `sources`. " +
+                "Default `name` is empty — `create_node` derives `\"<parent DataPoint name> graph\"` " +
+                "from the parent when no `name` is supplied, so siblings under different DataPoints don't collide.",
             metaFieldHints = mapOf(
                 "sources" to NODE_IDENTITY_HINT + " For Graph, populate with a single entry: the parent DataPoint's id + host.",
                 "targets" to NODE_IDENTITY_HINT + " Unused for Graph — leave empty.",

--- a/krill-mcp/krill-mcp-service/src/main/kotlin/krill/zone/mcp/mcp/tools/NodeTools.kt
+++ b/krill-mcp/krill-mcp-service/src/main/kotlin/krill/zone/mcp/mcp/tools/NodeTools.kt
@@ -99,6 +99,7 @@ class CreateNodeTool(private val registry: KrillRegistry) : Tool {
             )
         val parentTypeFqn = parentNode["type"]?.jsonObject?.get("type")?.jsonPrimitive?.contentOrNull
         val parentShortName = parentTypeFqn?.let { KrillNodeTypes.byTypeFqn[it]?.shortName }
+        val resolvedCallerName = callerName ?: derivedDefaultName(spec, parentNode)
 
         // Deterministic parent-type validation. Status values:
         //   ok                    — parentShortName is in spec.validParentTypes
@@ -116,7 +117,7 @@ class CreateNodeTool(private val registry: KrillRegistry) : Tool {
                 "(${spec.validParentTypes}). The server will still accept the post; confirm with the user."
         } else null
 
-        val mergedMeta = buildMergedMeta(spec, callerName, callerMeta)
+        val mergedMeta = buildMergedMeta(spec, resolvedCallerName, callerMeta)
 
         val newId = UUID.randomUUID().toString()
         val node = buildJsonObject {
@@ -152,6 +153,27 @@ class CreateNodeTool(private val registry: KrillRegistry) : Tool {
                 putJsonArray("warnings") { add(JsonPrimitive(parentValidationWarning)) }
             }
         }
+    }
+
+    /**
+     * For node types whose default name would collide across siblings (e.g.
+     * `KrillApp.DataPoint.Graph`), derive a parent-aware default from the
+     * verified parent node. Returns `null` when no derivation applies — the
+     * caller then falls through to the registry's `defaultMeta.name`.
+     *
+     * Graph rule: `"<parent DataPoint name> graph"` (parent is always a
+     * DataPoint per `validParentTypes`). Empty parent name yields `null` so
+     * we don't emit a leading-space artefact like `" graph"`.
+     */
+    internal fun derivedDefaultName(spec: KrillNodeType, parentNode: JsonObject): String? {
+        if (spec.shortName != "KrillApp.DataPoint.Graph") return null
+        val parentName = (parentNode["meta"] as? JsonObject)
+            ?.get("name")
+            ?.jsonPrimitive
+            ?.contentOrNull
+            ?.takeIf { it.isNotBlank() }
+            ?: return null
+        return "$parentName graph"
     }
 
     /**

--- a/krill-mcp/krill-mcp-service/src/test/kotlin/krill/zone/mcp/mcp/tools/CreateNodeToolTest.kt
+++ b/krill-mcp/krill-mcp-service/src/test/kotlin/krill/zone/mcp/mcp/tools/CreateNodeToolTest.kt
@@ -1,0 +1,67 @@
+package krill.zone.mcp.mcp.tools
+
+import krill.zone.mcp.auth.PinProvider
+import krill.zone.mcp.config.KrillMcpConfig
+import krill.zone.mcp.krill.KrillNodeTypes
+import krill.zone.mcp.krill.KrillRegistry
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Regression tests for issue bsautner/krill-oss#13.
+ *
+ * `create_node` must inject a parent-derived display name when creating a
+ * `KrillApp.DataPoint.Graph` and the caller did not supply one — otherwise
+ * sibling Graphs under different DataPoints all surface with the same name.
+ */
+class CreateNodeToolTest {
+
+    private val tool = CreateNodeTool(
+        registry = KrillRegistry(
+            config = KrillMcpConfig(),
+            pin = PinProvider(path = "/dev/null"),
+        ),
+    )
+    private val graphSpec = KrillNodeTypes.resolve("KrillApp.DataPoint.Graph")
+        ?: error("Graph spec missing from registry")
+    private val dataPointSpec = KrillNodeTypes.resolve("KrillApp.DataPoint")
+        ?: error("DataPoint spec missing from registry")
+
+    @Test
+    fun `derives parent-aware default for Graph from parent DataPoint name`() {
+        val parent = parentNode(typeFqn = "krill.zone.shared.KrillApp.DataPoint", name = "pH")
+        assertEquals("pH graph", tool.derivedDefaultName(graphSpec, parent))
+    }
+
+    @Test
+    fun `returns null for Graph when parent has no usable name`() {
+        val parent = parentNode(typeFqn = "krill.zone.shared.KrillApp.DataPoint", name = "")
+        assertNull(tool.derivedDefaultName(graphSpec, parent))
+    }
+
+    @Test
+    fun `returns null for non-Graph specs so other types keep their registry default`() {
+        val parent = parentNode(typeFqn = "krill.zone.shared.KrillApp.Server", name = "pi-krill-05")
+        assertNull(tool.derivedDefaultName(dataPointSpec, parent))
+    }
+
+    @Test
+    fun `Graph registry default name is empty so create_node always sources it from the parent or caller`() {
+        val defaultName = graphSpec.defaultMeta["name"]?.let { (it as JsonPrimitive).content }
+        assertEquals("", defaultName)
+    }
+
+    private fun parentNode(typeFqn: String, name: String) = buildJsonObject {
+        put(
+            "type",
+            buildJsonObject { put("type", JsonPrimitive(typeFqn)) },
+        )
+        put(
+            "meta",
+            buildJsonObject { put("name", JsonPrimitive(name)) },
+        )
+    }
+}

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/datapoint/graph/GraphMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/datapoint/graph/GraphMetaData.kt
@@ -22,7 +22,13 @@ import krill.zone.shared.node.TargetingNodeMetaData
  */
 @Serializable
 data class GraphMetaData(
-    val name: String = "Data Graph",
+    /**
+     * Display name. Empty string falls back to `"Graph"` in [krill.zone.shared.node.name].
+     * The previous default of `"Data Graph"` produced indistinguishable siblings under
+     * different parent DataPoints; callers (UI, MCP) are expected to supply a
+     * parent-derived name like `"<parent> graph"` at construction time.
+     */
+    val name: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
     /** Not used for graphs but required by the [TargetingNodeMetaData] contract. */
     override val targets: List<NodeIdentity> = emptyList(),

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/node/NodeFunctions.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/node/NodeFunctions.kt
@@ -72,7 +72,7 @@ fun Node.name(): String {
         KrillApp.Server, KrillApp.Server.Peer -> (this.meta as ServerMetaData).name
         KrillApp.Client -> (this.meta as krill.zone.shared.krillapp.client.ClientMetaData).name
         KrillApp.Server.Pin -> (this.meta as PinMetaData).name
-        KrillApp.DataPoint.Graph -> (this.meta as GraphMetaData).name
+        KrillApp.DataPoint.Graph -> (this.meta as GraphMetaData).name.ifEmpty { "Graph" }
         KrillApp.Project.TaskList -> (this.meta as TaskListMetaData).name
         KrillApp.Project.Journal -> (this.meta as JournalMetaData).name
         KrillApp.Project.Camera -> (this.meta as CameraMetaData).name.ifEmpty { "Camera" }

--- a/krill-sdk/src/commonTest/kotlin/krill/zone/shared/krillapp/datapoint/graph/GraphMetaDataTest.kt
+++ b/krill-sdk/src/commonTest/kotlin/krill/zone/shared/krillapp/datapoint/graph/GraphMetaDataTest.kt
@@ -1,0 +1,45 @@
+package krill.zone.shared.krillapp.datapoint.graph
+
+import krill.zone.shared.KrillApp
+import krill.zone.shared.node.Node
+import krill.zone.shared.node.name
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Regression tests for issue bsautner/krill-oss#13.
+ *
+ * The previous `GraphMetaData(name = "Data Graph")` default produced
+ * indistinguishable Graph siblings under different parent DataPoints; the
+ * fix removes the literal default and supplies a fallback at display time.
+ */
+class GraphMetaDataTest {
+
+    @Test
+    fun `default name is empty so callers must supply a parent-derived value`() {
+        val meta = GraphMetaData()
+        assertEquals("", meta.name)
+        assertNotEquals("Data Graph", meta.name)
+    }
+
+    @Test
+    fun `Node-name falls back to Graph when the meta name is empty`() {
+        val node = graphNode(name = "")
+        assertEquals("Graph", node.name())
+    }
+
+    @Test
+    fun `Node-name returns the supplied parent-derived name when present`() {
+        val node = graphNode(name = "pH graph")
+        assertEquals("pH graph", node.name())
+    }
+
+    private fun graphNode(name: String): Node = Node(
+        id = "graph-1",
+        parent = "datapoint-1",
+        host = "server-1",
+        type = KrillApp.DataPoint.Graph,
+        meta = GraphMetaData(name = name),
+    )
+}


### PR DESCRIPTION
## Summary

Fixes the `"Data Graph"` literal default in `GraphMetaData` that made every `KrillApp.DataPoint.Graph` sibling indistinguishable when its `name` wasn't set explicitly. Observed on `pi-krill-05` with three graphs under `nitrate` / `nitrite` / `pH` all named `"Data Graph"`.

## Approach

Followed suggestion (1) from the issue — parent-derived default at construction time — within the krill-oss boundary (the upstream UI factory in `bsautner/krill` is left for that repo):

- `krill-sdk/.../GraphMetaData.kt` — default `name = ""` instead of `"Data Graph"`.
- `krill-sdk/.../NodeFunctions.kt` — `Node.name()` falls back to `"Graph"` when the meta name is empty (matches the existing `Camera` / `Backup` `.ifEmpty { … }` pattern).
- `krill-mcp/.../KrillNodeTypes.kt` — Graph `defaultMeta.name = ""` so the MCP registry stops handing out the colliding literal.
- `krill-mcp/.../NodeTools.kt` `CreateNodeTool` — derives `"<parent DataPoint name> graph"` from the already-fetched parent when no `name` is supplied.

## Introducing commit

`05a6e38` — initial krill-sdk extraction with the literal default carried over from `bsautner/krill` `shared/`. The MCP registry default arrived later in `a185ce7`.

## Test plan

- [x] `./gradlew check` in `krill-sdk/` (commonTest passes on JVM)
- [x] `./gradlew :krill-mcp-service:test` (`CreateNodeToolTest` passes)
- [ ] On a live swarm: `create_node type=KrillApp.DataPoint.Graph parent=<dp-id>` with no `name` produces `meta.name = "<parent name> graph"`.

Closes #13

@qa-agent please verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)