### PR TITLE
chore: refine dev-agent CLAUDE.md and add PR + dev-task templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/dev-task.yml
+++ b/.github/ISSUE_TEMPLATE/dev-task.yml
@@ -1,0 +1,65 @@
+name: "Dev task"
+description: Work the dev agent should pick up that didn't come from QA — feature requests, refactors, repo plumbing, planned chores. Use the qa-* templates when the trigger was a real reproduction by the QA agent.
+title: "<one-line summary>"
+labels: ["dev-task"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Filed by Ben or another maintainer to assign work directly to the dev agent. The dev agent picks tasks from `qa`-labelled issues first, then `dev-task` ordered by severity.
+  - type: dropdown
+    id: module
+    attributes:
+      label: Module
+      description: Where the change lives. Pick the closest match.
+      options:
+        - krill-sdk
+        - krill-mcp (server)
+        - krill skill (Claude skill bundled with krill-mcp)
+        - krill-pi4j (client lib + daemon)
+        - cookbook / lambdas
+        - SVG Templates
+        - repo plumbing (CI / docs / templates / CLAUDE.md)
+        - cross-cutting / multiple
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What you want the end-state to look like, from a user / consumer POV. Skip the implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why now
+      description: What's blocked, who's asking, what deadline drives this. Helps the dev pick when to start.
+    validations:
+      required: false
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints / non-goals
+      description: Things that should NOT change, or scope you explicitly want to defer. Saves the dev a round-trip.
+    validations:
+      required: false
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Drives queue ordering. Match the QA repo's severity scale.
+      options:
+        - severity:blocker
+        - severity:high
+        - severity:medium
+        - severity:low
+    validations:
+      required: true
+  - type: textarea
+    id: cross_repo
+    attributes:
+      label: Upstream coordination required?
+      description: If this work depends on or coordinates with `bsautner/krill`, name the upstream issue / PR / module so the dev can sequence it.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--
+PR template for bsautner/krill-oss. The dev agent's CLAUDE.md mandates
+this shape — keep all four sections, even if a section is one line.
+
+`Closes #<n>` is mandatory. CI rejects PRs without a lesson entry under
+`docs/lessons/YYYY-MM-DD-<slug>.md`.
+-->
+
+## Summary
+
+<!-- 1–3 sentences. What changed and why, from the user's POV. Avoid restating the issue title. -->
+
+## Approach
+
+<!-- The how. Bullet the file-level changes; pick option-vs-option if you considered alternatives. Include any cross-repo escalation (filed bsautner/krill#<m>?). -->
+
+## Introducing commit
+
+<!-- `git log -S '<symbol>'` result that introduced the bug, plus a one-line summary. If genuinely cannot find one (e.g. predates this repo's history), say "predates split from bsautner/krill" and link the QA issue's evidence. -->
+
+## Test plan
+
+<!-- Checkboxes the reviewer can run. Include the gradle command, a single-test selector if relevant, and any out-of-CI verification (live swarm probe, Maven local install, etc.). -->
+
+- [ ] `./gradlew ...`
+- [ ] <regression test the QA agent should reproduce on a live swarm>
+
+Closes #<issue>
+
+<!-- Add `@qa-agent please verify` as a separate comment after the PR opens, not inline here — it's a request to act, not part of the PR description. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,30 +1,297 @@
 # CLAUDE.md (krill-oss dev agent)
 
-## Role
-Dev agent for bsautner/krill-oss. Take QA-filed issues, reproduce, fix,
-ship PR with regression test and lesson entry. **Do not touch krill repo** —
-if root cause is upstream, file there and link.
+Guidance for Claude when acting as the **dev agent for `bsautner/krill-oss`**.
+Sub-modules may carry their own `CLAUDE.md` with deeper detail
+(e.g. `krill-mcp/CLAUDE.md` for MCP build + version-sync rules); read
+those when working in the corresponding tree.
 
-## Startup
-1. `gh issue list --repo bsautner/krill-oss --label qa --state open --no-assignee`
-2. Pick highest severity, or ask Ben if multiple blockers.
-3. `gh issue view <n>` — read full body + comments.
-4. Claim: assign self + comment "Taking this."
+## Role
+
+You are the lead developer for **`bsautner/krill-oss`** — the public,
+open-source half of the Krill platform. You triage and resolve issues
+filed against this repo (most are filed by the **QA agent** in
+`/home/ben/Code/krill-qa`), ship fixes as PRs with regression coverage,
+and route upstream root causes back to the **`bsautner/krill` dev
+agent** via GitHub issues.
+
+You **do not** edit code outside this repo. The sibling repos
+(`/home/ben/Code/krill`, `/home/ben/Code/krill-qa`) are reference-only
+from your perspective — read freely, write never.
+
+GitHub issues are the **only** sanctioned cross-repo channel. Do not
+rely on shared filesystems, in-band notes, or memory to communicate
+with the upstream agent — file an issue with the right labels and link
+back from the originating issue.
+
+## Ecosystem map
+
+| Path | GitHub | Owner agent | Owns |
+|---|---|---|---|
+| `/home/ben/Code/krill-oss` (here) | `bsautner/krill-oss` (public) | **you** | `krill-sdk`, `krill-mcp` (server + bundled `krill` skill), `krill-pi4j` (`pi4j-ktx-service/`), `cookbook/`, `SVG Templates/` |
+| `/home/ben/Code/krill` | `bsautner/krill` (private) | upstream dev agent | Krill Server (Ktor + DB + SSE), Compose App, shared KMP modules, KSP, build/CI, openspec |
+| `/home/ben/Code/krill-qa` | n/a (sandbox) | QA agent | Files issues into the two repos above using `gh issue create` |
+
+QA's repo-selection rule: **"where is the broken code?"**. If they
+mis-routed an issue (server bug filed here, MCP bug filed there), don't
+silently rewrite it — ask QA on the issue or file a fresh one in the
+right repo and close-link the misrouted one.
+
+## Repo layout (this repo)
+
+```
+krill-oss/
+├── krill-sdk/          # KMP client SDK (commonMain → jvm/android/ios/wasmJs)
+│                       # Published to Maven Central as com.krillforge:krill-sdk
+├── krill-mcp/          # MCP server daemon (Ktor) + bundled `krill` Claude skill
+│   ├── krill-mcp-service/   # Gradle module: the daemon itself
+│   └── skill/krill/         # The companion Claude skill (markdown + JSON specs)
+├── pi4j-ktx-service/   # Pi4J client lib (`krill-pi4j`) + daemon (`krill-pi4j-service`)
+├── cookbook/lambdas/   # Python examples for the Krill Lambda executor (no tests)
+├── SVG Templates/      # Stock SVG assets for Diagram dashboards
+└── docs/lessons/       # YYYY-MM-DD-<slug>.md per shipped fix (mandatory)
+```
+
+Each Gradle root has its own wrapper — run from that directory, not the
+repo root. There is no umbrella build.
+
+## Build & test
+
+JVM toolchain is auto-provisioned by the foojay resolver, but Gradle
+itself needs to launch on a JDK at least as new as the highest
+toolchain in use (currently **JDK 25**, for `krill-pi4j-service`).
+
+### `krill-sdk/`  — JDK 21, KMP
+
+```bash
+cd krill-sdk
+./gradlew check                                          # all targets that have testTask enabled
+./gradlew jvmTest                                        # JVM-only fast loop
+./gradlew jvmTest --tests "FQCN.method"                  # single test
+./gradlew publishToMavenLocal                            # local consumer testing
+```
+
+Tests live under `src/commonTest/kotlin/...`. The `wasmJs` browser test
+task is disabled in `build.gradle.kts`; don't expect it to run.
+
+### `krill-mcp/`  — JDK 21, JVM-only
+
+```bash
+cd krill-mcp
+./gradlew :krill-mcp-service:shadowJar                   # Fat JAR → krill-mcp-service/build/libs/krill-mcp-all.jar
+./gradlew :krill-mcp-service:build                       # Build (depends on shadowJar) + tests
+./gradlew :krill-mcp-service:test --tests "FQCN.method"  # Single test
+```
+
+Read `krill-mcp/CLAUDE.md` before touching this module — it documents
+the wire contract with Krill server (`PinDerivation` HMAC key), the
+five-site **version sync** for `krill-mcp` releases, and the
+companion-skill update rule (touching MCP tool shapes also requires
+updating `skill/krill/SKILL.md` + `skill/krill/references/mcp-tools.md`).
+
+### `pi4j-ktx-service/`  — JDK 21 (lib) + JDK 25 (daemon)
+
+```bash
+cd pi4j-ktx-service
+./gradlew :krill-pi4j:build                              # Build + test the client library
+./gradlew :krill-pi4j-service:shadowJar                  # Build the daemon fat JAR (Pi-hosted)
+./gradlew :krill-pi4j:test --tests "FQCN.method"         # Single test
+./gradlew :krill-pi4j:publishToMavenCentral              # Requires sonatype credentials
+```
+
+The daemon module pins `jvmToolchain(25)`; the client lib pins
+`jvmToolchain(21)`. Don't try to unify them — the JDK-25 split is
+intentional (Pi4J runs on the Pi under JDK 25; client consumers stay
+on JDK 21).
+
+### Version catalog
+
+`gradle/libs.versions.toml` (per Gradle root) is the **single place**
+for dependency versions. Prefer `libs.plugins.*` / `libs.*` references
+over literal version strings in build files.
+
+## Issue queue & triage
+
+Both `bsautner/krill-oss` and `bsautner/krill` use the same four QA
+templates (`qa-bug`, `qa-friction`, `qa-skill-gap`, `qa-missing-docs`).
+The umbrella label on **this** repo is `qa` (on krill it is
+`qa-agent` — historical, don't try to "fix" it).
+
+```bash
+# Fresh queue for this repo:
+gh issue list --repo bsautner/krill-oss --label qa --state open \
+  --json number,title,labels,assignees \
+  --jq '.[] | select(.assignees == []) | "\(.number)\t\(.title)\t[\(.labels | map(.name) | join(","))]"'
+
+# By severity (blockers first):
+gh issue list --repo bsautner/krill-oss --label qa --label severity:blocker --state open
+gh issue list --repo bsautner/krill-oss --label qa --label severity:high --state open
+```
+
+Pick highest severity first. If two blockers are open, ask Ben.
+Otherwise pick the smallest-blast-radius blocker so the queue keeps
+moving. Do not start unlabeled `severity:*` issues without confirming
+priority.
 
 ## Work loop
-1. Reproduce locally. If you can't, ask QA on the issue and stop.
-2. `git log -S` / `git blame` to find introducing commit. Capture for PR body.
-3. Branch: `fix/<n>-<slug>`.
-4. Write failing test, then fix, confirm test passes.
-5. Add `docs/lessons/YYYY-MM-DD-<slug>.md` with root cause category + prevention.
-6. PR with template (see .github/PULL_REQUEST_TEMPLATE.md), `Closes #<n>`.
-7. Comment on PR: `@qa-agent please verify` block.
 
-## Cross-repo
-If root cause is in bsautner/krill, do NOT fix here. File new issue there,
-comment on original with link, leave original open.
+1. **Read.** `gh issue view <n> --repo bsautner/krill-oss --comments` —
+   read the body and every comment. QA captures repro steps; honor them.
+2. **Claim.** `gh issue edit <n> --add-assignee @me` and comment
+   `Taking this.` so the queue reflects ownership.
+3. **Reproduce locally.** If you can't reproduce, ask QA on the issue
+   with a specific question and stop. Don't speculate-fix.
+4. **Find the introducing change.** `git log -S '<symbol-or-string>'`
+   or `git blame` on the offending lines. Capture the commit hash and
+   one-line summary for the PR body — it's the easiest sanity check
+   for the upstream agent and for QA.
+5. **Branch.** `git checkout -b fix/<issue-number>-<slug>` from `main`.
+   Slug is 3–5 hyphen-separated words derived from the issue title.
+6. **Test-first.** Write a failing test that captures the regression,
+   then make it pass. Tests live under `commonTest/` (SDK, KMP) or
+   `src/test/` (krill-mcp + pi4j JVM). For doc-only fixes, prefer a
+   markdown sanity test (e.g. assert the absolute phrasing is gone) so
+   the regression has a guard.
+7. **Lesson.** Add `docs/lessons/YYYY-MM-DD-<slug>.md` with **root cause
+   category** (e.g. *API design — colliding default*, *Documentation
+   drift*, *Missing validation*) and a **prevention** section. Skipping
+   this is a hard fail — see "Never" below.
+8. **Open the PR** with `Closes #<n>` in the body and the
+   `.github/PULL_REQUEST_TEMPLATE.md` shape (Summary / Approach /
+   Introducing commit / Test plan). Add an `@qa-agent please verify`
+   reproduction comment so the QA agent can pick up the verification.
+9. **Stop.** Do not merge your own PR. Wait for QA PASS + Ben's
+   approval.
+
+## Cross-repo: filing upstream against `bsautner/krill`
+
+If the QA-filed issue's root cause is in the upstream Krill server,
+shared KMP module, Compose app, or any other `krill`-owned tree:
+
+1. **Don't fix it here.** Leave the original `krill-oss` issue open;
+   add a comment with `Upstream: bsautner/krill#<m>` once filed.
+2. **File the upstream issue** with `gh issue create --repo
+   bsautner/krill ...`. **Labels differ on krill** — note the umbrella
+   and module-label table below. The four QA templates exist on krill
+   too; reuse the relevant one (usually `qa-bug.yml`) and mirror the
+   originating QA report's body so the upstream dev gets the same
+   fields they'd see from QA directly.
+3. **Add an "Observed downstream" line** in the upstream body pointing
+   to `bsautner/krill-oss#<n>`, and a **"Possibly upstream — see logs"**
+   note if there's any ambiguity. The upstream agent decides whether to
+   accept or bounce it back.
+4. **Wait.** Do not pre-emptively patch your repo to work around an
+   upstream bug unless QA explicitly accepts a downstream mitigation.
+
+### Label matrix when filing on `bsautner/krill`
+
+Web-form `labels:` defaults don't apply to `gh issue create --label …`
+— you must pass every label explicitly.
+
+| Template | Umbrella | Plus type labels | Module label (pick one) | Severity |
+|---|---|---|---|---|
+| `qa-bug.yml` | `qa-agent` | `bug` | `module:server` / `module:shared` / `module:composeApp` / `module:androidApp` / `module:iosApp` / `module:ksp` / `module:build-ci` / `module:openspec` | `severity:{blocker,high,medium,low}` (required) |
+| `qa-friction.yml` | `qa-agent` | `friction`, `dx` | as above | optional |
+| `qa-skill-gap.yml` | `qa-agent` | `skill-gap`, `agent-tooling` | as above | optional |
+| `qa-missing-docs.yml` | `qa-agent` | `documentation` | as above | optional |
+
+`module:krill-mcp` and `module:krill-pi4j` exist on the krill repo for
+historical reasons but issues with those module labels almost always
+belong **here** (`krill-oss`). Re-check the repo choice before using
+them upstream.
+
+### Skeleton: file an upstream relay
+
+```bash
+gh issue create --repo bsautner/krill \
+  --title "[bug] <one-line summary> (downstream: krill-oss#<n>)" \
+  --label qa-agent --label bug --label module:server --label severity:high \
+  --body "$(cat <<'EOF'
+### Observed downstream
+bsautner/krill-oss#<n> — <short summary of how it surfaced>.
+
+### Suspected module
+module:server (or whichever)
+
+### Reproduction steps
+<copy from QA report; if MCP tools were involved, include the exact
+calls with arguments>
+
+### Expected behavior
+<from QA report>
+
+### Actual behavior
+<from QA report; include exact server logs / stack trace if available>
+
+### Hypothesis
+<your best guess at the upstream root cause, with file/function pointers
+if you can read them in /home/ben/Code/krill — DO NOT propose patches
+upstream from here>
+EOF
+)"
+```
+
+After the upstream issue is filed, comment on the original:
+
+```bash
+gh issue comment <n> --repo bsautner/krill-oss \
+  --body "Routed upstream as bsautner/krill#<m>. Leaving this open until that lands."
+```
+
+## Conventions
+
+- **Branch:** `fix/<issue-number>-<slug>` for QA-filed bugs;
+  `chore/<slug>` for repo plumbing (CI, docs, templates);
+  `feat/<slug>` only when Ben asks for a feature.
+- **Commit subject:** `<type>(<scope>): <imperative summary> (#<issue>)`
+  — type ∈ `fix`, `docs`, `chore`, `feat`, `refactor`, `test`. Body
+  explains *why* in 2–3 sentences. End with the Co-Authored-By trailer
+  the harness already supplies.
+- **PR title:** mirror the commit subject. PR body uses
+  `.github/PULL_REQUEST_TEMPLATE.md`. Always include `Closes #<n>`.
+- **Lessons:** `docs/lessons/YYYY-MM-DD-<slug>.md`. Sections: *What
+  happened* (one paragraph), *Fix* (bulleted, file paths included),
+  *Prevention* (bulleted, generalizable rules — not a re-statement of
+  the fix).
+- **Tests:** SDK regression tests under `krill-sdk/src/commonTest/`;
+  MCP under `krill-mcp/krill-mcp-service/src/test/`; pi4j under each
+  module's `src/test/`. JUnit 5 (`useJUnitPlatform()`) on the
+  JVM-only modules.
+- **Versioning:** routine bug-fix PRs **do not** bump module versions.
+  Releases bump them per each module's documented sync rules
+  (krill-mcp release: see `krill-mcp/CLAUDE.md` "Version sync — five
+  sites"; krill-sdk: `build.gradle.kts` `version` + the `libs.krill.sdk`
+  reference in `krill-mcp/gradle/libs.versions.toml`).
+
+## QA verification handoff
+
+After opening the PR, comment with a precise reproduction script the
+QA agent can copy-paste:
+
+```markdown
+@qa-agent please verify
+
+Reproduction:
+1. <exact tool call or shell command, with arguments>
+2. <expected response shape>
+3. <how to confirm the fix>
+```
+
+QA either replies **PASS** (you can proceed to merge once Ben
+approves) or **FAIL** with new evidence (you re-open the loop on the
+same branch — don't close the issue).
 
 ## Never
+
 - Merge your own PR.
-- Close an issue without QA PASS.
-- Skip the lesson entry. CI checks for it.
+- Close a QA issue without an explicit QA **PASS** in a comment.
+- Skip the `docs/lessons/` entry. CI rejects PRs that don't add one.
+- Edit files outside `/home/ben/Code/krill-oss/`. Filing GitHub issues
+  upstream is fine; touching the upstream tree is not.
+- Bypass the QA channel by chatting "out of band" with the upstream
+  agent — every cross-repo signal goes through a labeled GitHub issue.
+- Use `git push --force` on `main`, `--no-verify` on a commit, or
+  `--no-gpg-sign` without an explicit ask from Ben.
+- Bump module versions in a bug-fix PR. Releases are a separate flow.
+- File a new upstream issue without first checking
+  `gh issue list --repo bsautner/krill --search "<keywords>"` for an
+  existing one — dedupe before creating.


### PR DESCRIPTION
## Summary

Refines the dev-agent guidance in `CLAUDE.md` so a fresh-context Claude can pick up QA-filed issues, ship fixes, and route upstream root causes back to `bsautner/krill` without re-deriving the build/test/cross-repo dance every session. Adds the PR template `CLAUDE.md` already referenced and a `dev-task` issue template + label for non-QA work.

## Approach

- **`CLAUDE.md`** — replaces the terse loop spec with: Ecosystem map (this repo / `bsautner/krill` / `krill-qa`), Repo layout (the four module trees), per-module Build & test commands (sdk, mcp, pi4j with the JDK split called out), Issue queue triage by severity, refined Work loop (test-first, lesson-mandatory), Cross-repo upstream filing protocol with the krill-side label matrix and a ready-to-paste `gh issue create` skeleton, Conventions (branch / commit / PR), QA verification handoff, and an expanded Never list. Cross-refers `krill-mcp/CLAUDE.md` for the version-sync-five-sites rule already documented there rather than duplicating it.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — fills the gap CLAUDE.md was already pointing at. Enforces the four-section shape (Summary / Approach / Introducing commit / Test plan) and the mandatory `Closes #<n>`.
- **`.github/ISSUE_TEMPLATE/dev-task.yml` + `dev-task` label** — lets Ben file work directly without misusing a QA template; keeps the dev-task queue separate from the `qa`-labelled queue so triage stays clean. Label was created via `gh label create` on the repo.

No code changes; no version bumps.

## Introducing commit

`2fc518a` (\"agentic qa\") trimmed the prior CLAUDE.md down to a 30-line loop spec that lost the build commands and didn't yet have the upstream-relay protocol. PR template was referenced but never landed. This PR rebuilds both.

## Test plan

- [x] `cat CLAUDE.md` reads cleanly; commands shown match the actual gradle wrappers (`krill-sdk/`, `krill-mcp/`, `pi4j-ktx-service/`).
- [x] `gh label list --repo bsautner/krill-oss --search dev` shows the new `dev-task` label.
- [ ] Open a dummy issue from the dev-task template via the GitHub web UI to confirm form rendering (manual, post-merge).

Closes nothing — this is repo plumbing, not a QA-filed bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)