### PR TITLE
fix(ci): auto-dispatch krill-sdk publish on version bump (#17)

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -1,0 +1,109 @@
+name: release-sdk
+
+# Cross-repo automation for `com.krillforge:krill-sdk` Maven Central
+# releases. The actual publish workflow (Maven + Dokka + S3 + CloudFront)
+# lives in the private `bsautner/krill` repo because the signing /
+# Sonatype / AWS secrets live there. This workflow detects a krill-sdk
+# version bump on `main` and dispatches that upstream workflow with the
+# new version, so the publish pipeline doesn't need a manual button-press
+# in the private repo on every release.
+#
+# Required repo secret:
+#   KRILL_PUBLISH_TOKEN — fine-grained PAT or GitHub App token scoped to
+#     `bsautner/krill` with `Actions: read+write` and `Contents: read`.
+#     Rotate independently of `GITHUB_TOKEN`; this token never reaches
+#     non-dispatch steps.
+#
+# Manual override:
+#   The `workflow_dispatch` trigger lets you republish a specific version
+#   from the Actions tab without bumping `build.gradle.kts` (e.g. when an
+#   upstream publish step failed mid-run and Maven Central rejected the
+#   first attempt).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'krill-sdk/build.gradle.kts'
+      - '.github/workflows/release-sdk.yml'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.0.17). Leave blank to read from krill-sdk/build.gradle.kts."
+        required: false
+        type: string
+
+# Releases must serialise — never cancel an in-flight dispatch.
+concurrency:
+  group: release-sdk
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    name: Dispatch upstream Maven publish
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need HEAD~1 to diff the version line.
+          fetch-depth: 2
+
+      - name: Resolve target version
+        id: version
+        run: |
+          set -euo pipefail
+          manual="${{ inputs.version }}"
+          new_version=$(grep -E '^version = ' krill-sdk/build.gradle.kts | head -1 | sed -E 's/^version = "([^"]+)"/\1/')
+          old_version=$(git show HEAD~1:krill-sdk/build.gradle.kts 2>/dev/null \
+            | grep -E '^version = ' | head -1 | sed -E 's/^version = "([^"]+)"/\1/' || true)
+          target="${manual:-$new_version}"
+          echo "old=${old_version:-<none>}"   >> "$GITHUB_OUTPUT"
+          echo "new=$new_version"             >> "$GITHUB_OUTPUT"
+          echo "target=$target"               >> "$GITHUB_OUTPUT"
+          if [ -n "$manual" ]; then
+            echo "reason=manual workflow_dispatch (version=$manual)"     >> "$GITHUB_OUTPUT"
+            echo "should_dispatch=true"                                  >> "$GITHUB_OUTPUT"
+          elif [ "$new_version" = "${old_version:-}" ]; then
+            echo "reason=krill-sdk/build.gradle.kts touched but version unchanged ($new_version)" >> "$GITHUB_OUTPUT"
+            echo "should_dispatch=false"                                 >> "$GITHUB_OUTPUT"
+          else
+            echo "reason=version bumped: ${old_version:-<none>} → $new_version" >> "$GITHUB_OUTPUT"
+            echo "should_dispatch=true"                                  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summarise decision
+        run: |
+          {
+            echo "## release-sdk decision"
+            echo ""
+            echo "- Old version: \`${{ steps.version.outputs.old }}\`"
+            echo "- New version: \`${{ steps.version.outputs.new }}\`"
+            echo "- Target version: \`${{ steps.version.outputs.target }}\`"
+            echo "- Will dispatch: \`${{ steps.version.outputs.should_dispatch }}\`"
+            echo "- Reason: ${{ steps.version.outputs.reason }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dispatch publish workflow on bsautner/krill
+        if: ${{ steps.version.outputs.should_dispatch == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.KRILL_PUBLISH_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.target }}"
+          if [ -z "$version" ]; then
+            echo "::error::Could not resolve a version to publish."
+            exit 1
+          fi
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::KRILL_PUBLISH_TOKEN secret is not set on bsautner/krill-oss. Add a fine-grained PAT scoped to bsautner/krill with Actions: read+write."
+            exit 1
+          fi
+          echo "Dispatching: gh workflow run 'Publish Krill-SDK Maven.yml' --repo bsautner/krill --ref main -f version=$version"
+          gh workflow run "Publish Krill-SDK Maven.yml" \
+            --repo bsautner/krill \
+            --ref main \
+            -f version="$version"
+          echo "::notice::Dispatched bsautner/krill publish for krill-sdk@$version. Watch: https://github.com/bsautner/krill/actions/workflows/Publish%20Krill-SDK%20Maven.yml"

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -67,7 +67,7 @@ jobs:
             echo "reason=manual workflow_dispatch (version=$manual)"     >> "$GITHUB_OUTPUT"
             echo "should_dispatch=true"                                  >> "$GITHUB_OUTPUT"
           elif [ "$new_version" = "${old_version:-}" ]; then
-            echo "reason=krill-sdk/build.gradle.kts touched but version unchanged ($new_version)" >> "$GITHUB_OUTPUT"
+            echo "reason=workflow triggered but version unchanged ($new_version)" >> "$GITHUB_OUTPUT"
             echo "should_dispatch=false"                                 >> "$GITHUB_OUTPUT"
           else
             echo "reason=version bumped: ${old_version:-<none>} → $new_version" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -98,7 +98,7 @@ jobs:
             exit 1
           fi
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::KRILL_PUBLISH_TOKEN secret is not set on bsautner/krill-oss. Add a fine-grained PAT scoped to bsautner/krill with Actions: read+write."
+            echo "::error::KRILL_PUBLISH_TOKEN secret is not set on bsautner/krill-oss. Add a fine-grained PAT scoped to bsautner/krill with Actions: read+write and Contents: read."
             exit 1
           fi
           echo "Dispatching: gh workflow run 'Publish Krill-SDK Maven.yml' --repo bsautner/krill --ref main -f version=$version"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,11 +256,27 @@ gh issue comment <n> --repo bsautner/krill-oss \
   MCP under `krill-mcp/krill-mcp-service/src/test/`; pi4j under each
   module's `src/test/`. JUnit 5 (`useJUnitPlatform()`) on the
   JVM-only modules.
-- **Versioning:** routine bug-fix PRs **do not** bump module versions.
-  Releases bump them per each module's documented sync rules
-  (krill-mcp release: see `krill-mcp/CLAUDE.md` "Version sync — five
-  sites"; krill-sdk: `build.gradle.kts` `version` + the `libs.krill.sdk`
-  reference in `krill-mcp/gradle/libs.versions.toml`).
+- **Versioning:**
+  - **`krill-sdk`** — every PR that changes anything under `krill-sdk/**`
+    **must also bump the patch** in `krill-sdk/build.gradle.kts` (e.g.
+    `0.0.17` → `0.0.18`). CI (`.github/workflows/release-sdk.yml`)
+    detects the bump on push to `main` and dispatches the upstream
+    Maven publish workflow in `bsautner/krill` automatically — there is
+    no manual republish step. Skipping the bump silently leaves the fix
+    out of Maven Central; the build still passes, so be deliberate.
+    Dispatch requires the `KRILL_PUBLISH_TOKEN` repo secret (fine-grained
+    PAT scoped to `bsautner/krill` with `Actions: read+write`,
+    `Contents: read`); the workflow surfaces a clear error if it's
+    missing.
+  - **`krill-sdk` consumer pin** — `krill-mcp/gradle/libs.versions.toml`
+    has `krill-sdk = "x.y.z"`. Only bump it in a follow-up PR **after**
+    the new artifact is live on Maven Central. Pinning to a yet-unpublished
+    version breaks the krill-mcp build.
+  - **`krill-mcp`** — bug-fix PRs **do not** bump version. Releases
+    follow `krill-mcp/CLAUDE.md` "Version sync — five sites" and ship
+    the Debian package; treat that as a separate, deliberate flow.
+  - **`krill-pi4j`** — bug-fix PRs do not bump version. Releases are
+    coordinated with the upstream Pi4J Maven publish workflow.
 
 ## QA verification handoff
 

--- a/docs/lessons/2026-04-27-release-sdk-cross-repo-dispatch.md
+++ b/docs/lessons/2026-04-27-release-sdk-cross-repo-dispatch.md
@@ -1,0 +1,67 @@
+# krill-sdk releases needed manual cross-repo dispatch
+
+**Issue:** [krill-oss#17](https://github.com/bsautner/krill-oss/issues/17)
+**Root cause category:** CI/CD friction — split source-of-truth and
+publish pipeline across two repos with no automatic handoff
+**Module:** `krill-sdk` (build), repo plumbing (CI)
+
+## What happened
+
+`krill-sdk` source lives in this repo, but the Maven Central publish
+workflow lives in the **private** `bsautner/krill` repo (because the
+Sonatype / GPG / AWS / CloudFront secrets live there). A merge to
+`krill-oss/main` that touched `krill-sdk/` produced no published
+artifact until someone manually opened `bsautner/krill`'s Actions tab,
+clicked **Run workflow** on `Publish Krill-SDK Maven.yml`, and typed
+the new version. QA #156 / krill-oss #14 sat for ~5 hours after merge
+with no consumer-visible artifact, surfacing as krill-oss #17 from the
+upstream dev agent.
+
+Two contributing factors:
+
+- The dev agent's CLAUDE.md explicitly told it **not** to bump module
+  versions in bug-fix PRs. So even when a fix landed, the
+  `build.gradle.kts` `version` line on `main` matched the
+  already-published Maven Central version, and the publish workflow's
+  default would just re-publish the same coordinates (which Maven
+  Central rejects).
+- The publish workflow is the obvious place to bump and dispatch
+  automatically, but it lives in a repo this dev agent doesn't write to.
+
+## Fix
+
+- **Per-PR bump rule.** Every PR touching `krill-sdk/**` now bumps the
+  patch in `krill-sdk/build.gradle.kts` in the same change. CLAUDE.md's
+  *Conventions → Versioning* section was rewritten to document this
+  (and to keep the *don't bump* rule for `krill-mcp` / `krill-pi4j`,
+  which release deliberately, not per-PR).
+- **Auto-dispatch workflow.** `.github/workflows/release-sdk.yml`
+  triggers on push to `main` when `krill-sdk/build.gradle.kts` changes,
+  detects whether the version line actually moved (vs. unrelated edits
+  to that file), and calls
+  `gh workflow run "Publish Krill-SDK Maven.yml" --repo bsautner/krill`
+  with the new version. Manual `workflow_dispatch` trigger is preserved
+  for republishes after a half-failed upstream run.
+- **Token plumbing.** Dispatch uses a `KRILL_PUBLISH_TOKEN` repo secret
+  (fine-grained PAT, scoped to `bsautner/krill` with `Actions:
+  read+write`, `Contents: read`). The workflow checks for the token
+  and surfaces an actionable error if it's missing — rather than
+  silently 401-ing.
+
+## Prevention
+
+- When a "release-on-demand" pipeline lives in a different repo from
+  its source, treat the **dispatch** as a first-class CI concern, not
+  a wiki step. Manual-dispatch friction grows linearly with release
+  cadence; automation is one workflow file away.
+- Source-of-truth versions should live next to the code they describe
+  (`build.gradle.kts` here), not in the publish workflow's input. The
+  publish workflow should *honour* the in-repo version, not invent it.
+- A "don't bump versions in bug-fix PRs" rule is correct for downstream
+  modules with deliberate release cadences (e.g. Debian-packaged
+  daemons). It's wrong for upstream library modules whose downstream
+  consumers can't pick up a fix until a new artifact lands. Tag the
+  rule per module, not per repo.
+- The `concurrency: cancel-in-progress: false` setting on release
+  workflows matters: cancelling a publish mid-upload can leave a
+  partial release on Maven Central that's painful to clean up.

--- a/krill-sdk/build.gradle.kts
+++ b/krill-sdk/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "com.krillforge"
-version = "0.0.16"
+version = "0.0.17"
 
 kotlin {
     jvmToolchain(21)


### PR DESCRIPTION
## Summary

Fixes the cross-repo CI/CD friction that left `krill-sdk` fixes stranded on `main` — merged but not republished to Maven Central — until someone manually clicked **Run workflow** in the private `bsautner/krill` repo. #14's Graph default-name fix has been on main since 2026-04-26 but no consumer-visible artifact has been cut for it. This PR republishes as `0.0.17` and automates the dispatch so it doesn't recur.

## Approach

Two-part fix, plus a documentation rule so future PRs play nicely:

1. **Per-PR patch bump for `krill-sdk`.** `CLAUDE.md` *Conventions → Versioning* rewritten. Every PR touching `krill-sdk/**` now bumps the patch in `krill-sdk/build.gradle.kts` in the same change. The previous *don't bump in bug-fix PRs* rule still applies to `krill-mcp` and `krill-pi4j` (deliberate release cadences) but was wrong for an upstream library whose downstream consumers can't pick up a fix until a new artifact is on Maven Central.

2. **Auto-dispatch on `main`.** `.github/workflows/release-sdk.yml`:
   - Triggers on `push` to `main` filtered to `krill-sdk/build.gradle.kts` (plus a manual `workflow_dispatch` for republishes after a half-failed upstream run).
   - Diffs the `version = "..."` line between `HEAD` and `HEAD~1`; only dispatches when it actually moved (other edits to the same file shouldn't trigger).
   - Calls `gh workflow run \"Publish Krill-SDK Maven.yml\" --repo bsautner/krill --ref main -f version=<new>` using a `KRILL_PUBLISH_TOKEN` repo secret. The upstream workflow already accepts `version` as input and checks out `bsautner/krill-oss` `main`, so no upstream changes are needed.
   - `concurrency: cancel-in-progress: false` — releases serialise and never cancel mid-publish (a cancelled mid-upload to Maven Central is worse than one that runs to completion).
   - Surfaces an actionable error if `KRILL_PUBLISH_TOKEN` isn't set, instead of silently 401-ing.

3. **Bump `krill-sdk` 0.0.16 → 0.0.17** so the dispatch actually fires when this PR merges, picking up #14.

`docs/lessons/2026-04-27-release-sdk-cross-repo-dispatch.md` captures the friction and prevention.

## Setup required before merge

Add the `KRILL_PUBLISH_TOKEN` repo secret on `bsautner/krill-oss`. Fine-grained PAT scoped to `bsautner/krill` only with:
- **Actions:** read & write
- **Contents:** read

Without this, the `release-sdk` workflow logs an error and exits non-zero on first push to main; the upstream publish doesn't happen.

## Introducing commit

n/a — release flow has been manual since `bsautner/krill`'s \"Publish Krill-SDK Maven.yml\" was added (predates this repo's split). The new friction surfaced now because of the split: source-of-truth (krill-sdk) lives here, secrets (Sonatype/GPG/AWS) live in `bsautner/krill`.

## Test plan

- [x] YAML parses (\`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release-sdk.yml'))\"\`).
- [x] Bash version-extraction works against current build.gradle.kts (returns `0.0.17`).
- [ ] On merge to main: \`release-sdk\` workflow runs, detects the bump, dispatches \`bsautner/krill\` → \`Publish Krill-SDK Maven.yml\` with \`version=0.0.17\`. Upstream pipeline publishes to Maven Central.
- [ ] After publish lands: \`curl -sI https://repo1.maven.org/maven2/com/krillforge/krill-sdk/0.0.17/krill-sdk-0.0.17.module\` returns 200; sources jar contains the GraphMetaData fix from #14.
- [ ] Follow-up (separate PR, not this one): bump `krill-mcp/gradle/libs.versions.toml` `krill-sdk = \"0.0.17\"` once the artifact is live.
- [ ] Negative path: push a commit that touches `krill-sdk/build.gradle.kts` without changing the `version =` line — workflow runs but the dispatch step is skipped (job summary shows \"krill-sdk/build.gradle.kts touched but version unchanged\").

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)