### PR TITLE
docs(skill): add voice/NL command → action workflow recipe (#27)

### DIFF
--- a/docs/lessons/2026-04-29-voice-flow-recipe.md
+++ b/docs/lessons/2026-04-29-voice-flow-recipe.md
@@ -1,0 +1,107 @@
+# Skill missing a natural-language → action workflow recipe
+
+**Issue:** [krill-oss#27](https://github.com/bsautner/krill-oss/issues/27)
+**Root cause category:** Skill-gap — primitives existed, recipe did not
+**Module:** `krill-mcp` companion skill (`skill/krill/SKILL.md`)
+
+## What happened
+
+A QA agent on a Claude Desktop voice flow tried to act on *"turn on
+the Vivarium mister"*. The skill covered discovery, multi-node
+authoring, diagram authoring, and time-series writes, but had **no
+recipe for the natural-language → action chain end-to-end** — the
+flow that has its own choreography because voice has no inline diff
+and a ~1-turn confirmation budget.
+
+The agent reasoned every step from primitives:
+
+1. Picked the only registered server (`pi-krill-05`) instead of
+   resolving the phrase against the swarm.
+2. Found a `LogicGate` (BUFFER) inside the local Vivarium project and
+   chose it as the target — wrong: the actual mister-toggling NOT
+   gate lives on `pi-krill.local`, which the registry didn't know
+   about (`#23`).
+3. Could not invoke a manual fire because no `execute_node` exists
+   (`#24`); fell back to considering `record_snapshot`, which felt
+   wrong for a voice flow because it pollutes the upstream
+   DataPoint's history.
+4. Gave up and asked QA for triage instead of firing.
+
+A user expecting *"turn on the mister"* to just work would hear
+silence (or a multi-turn exploration that defeats the point of voice).
+The primitives — `find_node` (`#26`, just shipped), `record_snapshot`,
+the catalog's `llmSideEffectLevel`, the parent/source/target wiring on
+`LogicGate` — were all there. Without a recipe stringing them together
+with the safety pattern (confirm against the *target's* side-effect
+level, not the executor's), every voice flow had to invent it.
+
+## Fix
+
+Added a top-level workflow section to `SKILL.md`:
+**"For 'natural-language commands → action' (voice or chat-mode
+requests)"**. Five numbered steps:
+
+1. **Resolve the target** via a single `find_node` call; ask the user
+   only when two or more candidates score within ~0.1 of each other.
+2. **Resolve the action** by mapping verbs ("turn on", "toggle") to a
+   `LogicGate` whose `meta.target` is the named Pin/DataPoint.
+3. **Confirm against the target's `llmSideEffectLevel`, not the
+   executor's** — a LogicGate is `medium`, but the Pin it writes to
+   is `high`, which is the real-world side effect.
+4. **Fire** via `execute_node` when available (tracked as `#24`,
+   not yet shipped); fall back to `record_snapshot` on the gate's
+   source DataPoint *with a once-per-session warning* that this
+   writes a synthetic reading into the upstream history.
+5. **Report** by re-reading the target after a 1–2 second delay.
+
+Added a "Failure modes to avoid" list calling out: silent
+disambiguation; firing high-side-effect actions without
+confirmation; using `record_snapshot` as a silent `execute`
+substitute; multi-turn breadth-first exploration as a substitute
+for one `find_node` call.
+
+Added regression tests in `SkillRulesTest`:
+- `skill has a natural-language commands workflow recipe`
+- `voice-flow recipe spells out the resolve-confirm-fire chain`
+  (asserts `find_node`, target-side-effect anchoring, `execute_node`
+  preference)
+- `voice-flow recipe warns against the snapshot-as-execute footgun`
+  (asserts the synthetic-reading warning is present)
+
+## Prevention
+
+- **When primitives exist but agents still flounder, the missing
+  piece is usually a recipe.** A skill is not just a tools index;
+  it's the choreography that strings tools together for specific
+  user intents. Discovery + record + diagram recipes existed;
+  natural-language action did not, and that gap dominated the voice
+  experience even after the underlying tools were fine.
+- **Anchor safety on the *target* of the action, not the
+  intermediary.** A LogicGate's `llmSideEffectLevel` is `medium`,
+  but the Pin it writes to (the real-world thing the user perceives)
+  is `high`. An agent checking only the gate's level would fire a
+  mister/lamp/valve without confirmation. Recipes that involve
+  executors must explicitly point the safety check at what the
+  executor *does*, not what the executor *is*.
+- **Voice flows have a hard ~1-turn confirmation budget.** Any
+  recipe for them needs to converge in 1–2 round-trips on the happy
+  path and fall back to exactly one disambiguating question on the
+  edge cases. Patterns that involve exploration ("scan every
+  server, filter, ask the user which one") fail in voice because
+  the user perceives them as silence. Always pair an
+  exploration-flavoured suggestion with a single composite primitive
+  that collapses the round-trips (`find_node` here; whatever the
+  next equivalent is for future flows).
+- **Document fallbacks with their costs visible.** The
+  `record_snapshot`-on-the-gate's-source workaround works, but
+  silently leaves a synthetic reading in the upstream DataPoint's
+  history. The recipe needs to make that visible to the user once
+  per session so they can decide whether to wait for `execute_node`
+  or accept the trade-off — agents that pretend the fallback is a
+  drop-in replacement teach users to distrust the swarm's data.
+- **Skill recipes need regression tests.** A markdown assertion that
+  the recipe still mentions `find_node` / `execute_node` /
+  `synthetic` is enough to catch a future "cleanup" pass that
+  rewrites the section in a way that drops the safety pattern. The
+  test is cheap; the cost of silently dropping a recipe is
+  invisible until the next voice user.

--- a/krill-mcp/krill-mcp-service/src/test/kotlin/krill/zone/mcp/skill/SkillRulesTest.kt
+++ b/krill-mcp/krill-mcp-service/src/test/kotlin/krill/zone/mcp/skill/SkillRulesTest.kt
@@ -48,6 +48,67 @@ class SkillRulesTest {
         )
     }
 
+    /**
+     * Regression test for issue bsautner/krill-oss#27.
+     *
+     * The skill was missing a workflow recipe for natural-language
+     * action requests ("turn on the Vivarium mister"). Without it,
+     * agents in voice flows reasoned every step from primitives,
+     * fired wrong-target on close-score candidates, and silently
+     * fell back to `record_snapshot` for *execute*-shaped requests.
+     * The new section codifies a single resolve → confirm → fire →
+     * report chain anchored on `find_node` and the target's
+     * `llmSideEffectLevel`.
+     */
+    @Test
+    fun `skill has a natural-language commands workflow recipe`() {
+        val text = skillFile.readText()
+        assertTrue(
+            "natural-language commands" in text || "natural-language command" in text,
+            "SKILL.md should include a workflow section for natural-language action " +
+                "requests (voice or chat-mode). See issue #27.",
+        )
+    }
+
+    @Test
+    fun `voice-flow recipe spells out the resolve-confirm-fire chain`() {
+        val text = skillFile.readText()
+        val resolveMentionsFindNode =
+            ("Resolve the target" in text) && ("find_node" in text)
+        val confirmsOnTargetSideEffect =
+            "target's" in text && "llmSideEffectLevel" in text
+        val firePrefersExecuteNode = "execute_node" in text
+        assertTrue(
+            resolveMentionsFindNode,
+            "Voice-flow recipe should resolve targets via `find_node` (a single composite " +
+                "primitive) — see issue #27 for why scan/filter/match per server isn't a viable " +
+                "voice-flow pattern.",
+        )
+        assertTrue(
+            confirmsOnTargetSideEffect,
+            "Voice-flow recipe should anchor confirmation on the *target's* `llmSideEffectLevel`, " +
+                "not the executor's — a LogicGate is `medium` but the Pin it writes to is `high`.",
+        )
+        assertTrue(
+            firePrefersExecuteNode,
+            "Voice-flow recipe should mention `execute_node` (tracked as #24) as the preferred " +
+                "fire path, with the `record_snapshot` fallback documented as a stopgap.",
+        )
+    }
+
+    @Test
+    fun `voice-flow recipe warns against the snapshot-as-execute footgun`() {
+        val text = skillFile.readText()
+        val mentionsSyntheticOrPolluting =
+            "synthetic" in text || "pollut" in text
+        assertTrue(
+            mentionsSyntheticOrPolluting,
+            "Voice-flow recipe should call out that `record_snapshot` writes a synthetic reading " +
+                "into the source DataPoint's history — agents must surface the trade-off and not " +
+                "silently use it as an `execute` substitute. See issue #27.",
+        )
+    }
+
     private companion object {
         const val SKILL_PATH = "../skill/krill/SKILL.md"
     }

--- a/krill-mcp/skill/krill/SKILL.md
+++ b/krill-mcp/skill/krill/SKILL.md
@@ -89,6 +89,37 @@ Read these on demand — they're not auto-loaded:
 5. Overlay type-specific fields via the `meta` argument — e.g. `{"dataType": "DOUBLE", "unit": "°C", "precision": 1}` for a temperature DataPoint, `{"value": 100.0}` for a HighThreshold. Unknown keys are silently dropped by the server (`ignoreUnknownKeys = true`), so extras are safe but typos go unnoticed — stick to the field names in the MetaData classes.
 6. **Verify with `get_node`** after each create. The `create_node` response echoes what was sent, not what persisted; a round-trip read is the only ground truth. The server also **fills in defaults for meta fields you omitted** (e.g. a DataPoint you posted without a `snapshot` comes back with `snapshot: {timestamp: 0, value: ""}`) — not an error, but it's why the GET is authoritative.
 
+### For "natural-language commands → action" (voice or chat-mode requests)
+
+When the user gives an action-shaped request that names a thing in plain language — *"turn on the Vivarium mister"*, *"toggle the porch lamp"*, *"log a temperature reading of 72"* — the goal is to converge in 1–2 round-trips when the swarm is unambiguous and short-circuit to a single confirmation question when it isn't. Voice flows have no inline diff and no rendered tool-call to read; the user said *"turn it on"* and either gets the action or one follow-up question.
+
+1. **Resolve the target.** Call `find_node(query, type?)` once with the user's phrase (e.g. `query: "vivarium mister", type: "Pin"`). It iterates every registered server and returns ranked `(serverId, nodeId)` candidates. Decision rule:
+   - Top score `>= 0.9` and clearly above the runner-up (gap `>~ 0.1`) → fire on it.
+   - Two or more candidates within `~0.1` of each other → **ask the user which one**, by server + displayName, never by UUID. Voice example: *"I see two — the Vivarium mister on `pi-krill.local` and the test mister on `pi-krill-05.local`. Which one?"*
+   - Empty result → tell the user the phrase didn't match anything in the swarm and stop. Don't speculate-substitute.
+
+   If `find_node` is not available in the session, fall back to: `list_servers` → for each server, `list_nodes type=<inferred>` → match `displayName` against the user's phrase tokens. Apply the same disambiguation rule.
+
+2. **Resolve the action.** "Turn on" / "turn off" / "toggle" maps to firing a `KrillApp.Executor.LogicGate` whose `meta.target` is the named Pin or DataPoint. From the resolved target, look up the controlling gate: walk `meta.parent` upward, or `list_nodes type=LogicGate` on the same server and pick the one whose `meta.target` references the resolved node id. "Log a value" / "record" maps to `record_snapshot` directly on the named DataPoint (covered in the next workflow). "Read" / "what is" maps to `get_node` or `read_series`.
+
+3. **Confirm — based on the *target's* side-effect level, not the executor's.** A LogicGate is `llmSideEffectLevel: "medium"`, but the Pin it writes to is `"high"` — a mister, lamp, valve, or relay is the real-world side effect. Look at the **target** node's catalog `llmSideEffectLevel` (cross-reference `references/node-types/INDEX.md`):
+   - **`high`** (Pins, OutgoingWebHook, Lambda, Email/SMS, Camera capture) → **ALWAYS confirm in one short voice-friendly turn.** Include server name + current state so the user can hear what's about to change. Voice example: *"Toggle the Vivarium mister on `pi-krill.local` now? It's currently off."* Wait for an affirmative response before step 4. Do not fire on an ambiguous response — re-ask.
+   - **`medium`** → confirm only if step 1 returned multiple close candidates, or if the user's phrase was indirect (*"do the mister thing"* vs *"toggle the mister"*). Otherwise fire directly.
+   - **`low`** → fire directly, no confirmation.
+
+4. **Fire.** Prefer `execute_node` when available (tracked as `bsautner/krill-oss#24`; not shipped at v0.0.8). Until it lands, the only way to fire a gate from MCP is to **`record_snapshot` to the gate's `meta.sources[0].nodeId`** with a value that flips its evaluation (DOUBLE: `1.0` / `0.0`; DIGITAL: `1` / `0`; the gate then writes the result to its target Pin). Constraints when using the snapshot fallback:
+   - Only after step 3's confirmation has been received.
+   - Warn the user **once per session** that this writes a synthetic reading into the source DataPoint's history: *"Heads up — until `execute_node` ships, firing the gate writes a synthetic snapshot into the source DataPoint. The mister will toggle but you'll see an extra reading on the upstream sensor."*
+   - If the user says they want to *execute* (not log), and only the snapshot path is available, surface the trade-off and let them decide. Don't silently pollute history.
+
+5. **Report.** After a 1–2 second delay (the gate evaluates async), `get_node` on `meta.targets[0].nodeId` (or the resolved target Pin) and speak the new state — *"Mister on."* / *"Lamp off."* — short enough to fit voice. If the read shows the state didn't change, say so and stop; don't loop.
+
+**Failure modes to avoid in this flow:**
+- Silently picking from multiple candidates when scores are close. The whole point of the confirmation budget is to spend one turn on disambiguation rather than fire wrong.
+- Firing a `high`-side-effect action without confirmation, even if the phrase is unambiguous. *"Turn on the mister"* is not consent to a specific server's mister.
+- Falling back to `record_snapshot` when the user explicitly asked to *execute* something — the snapshot pattern is a stopgap for the missing `execute_node` tool, not a voice answer. Always surface the trade-off.
+- Multi-turn breadth-first exploration (`list_servers` → walk every server → ask the user to clarify the intent). Voice has no budget for it; resolve in one `find_node` call or escalate to a single confirmation question.
+
 ### For "record values to a DataPoint" (single value or a backfill series)
 1. Get the target DataPoint id (via `list_nodes type=DataPoint` or straight from the user).
 2. Call `record_snapshot` with either `{dataPointId, value, timestamp?}` for a single reading or `{dataPointId, snapshots: [{timestamp, value}, ...]}` for a series. `timestamp` is epoch **milliseconds**. **If MCP tools aren't in-session**, snapshot writes have **no Krill REST endpoint** — don't probe `/data`, `/snapshot`, `/data/record`, etc. on `:8442` (they 404). Use the **Direct-to-MCP JSON-RPC fallback** in `references/mcp-tools.md` to reach `record_snapshot` through `http://<host>:50052/mcp`.

--- a/krill-mcp/skill/krill/SKILL.md
+++ b/krill-mcp/skill/krill/SKILL.md
@@ -93,12 +93,12 @@ Read these on demand — they're not auto-loaded:
 
 When the user gives an action-shaped request that names a thing in plain language — *"turn on the Vivarium mister"*, *"toggle the porch lamp"*, *"log a temperature reading of 72"* — the goal is to converge in 1–2 round-trips when the swarm is unambiguous and short-circuit to a single confirmation question when it isn't. Voice flows have no inline diff and no rendered tool-call to read; the user said *"turn it on"* and either gets the action or one follow-up question.
 
-1. **Resolve the target.** Call `find_node(query, type?)` once with the user's phrase (e.g. `query: "vivarium mister", type: "Pin"`). It iterates every registered server and returns ranked `(serverId, nodeId)` candidates. Decision rule:
-   - Top score `>= 0.9` and clearly above the runner-up (gap `>~ 0.1`) → fire on it.
-   - Two or more candidates within `~0.1` of each other → **ask the user which one**, by server + displayName, never by UUID. Voice example: *"I see two — the Vivarium mister on `pi-krill.local` and the test mister on `pi-krill-05.local`. Which one?"*
+1. **Resolve the target.** In current releases, use the shipped MCP tools directly: `list_servers` → for each server, `list_nodes type=<inferred>` → match `displayName` against the user's phrase tokens. Apply this decision rule:
+   - One clear best match (for example, an exact/near-exact name match that is clearly better than the others) → use it.
+   - Two or more plausible candidates → **ask the user which one**, by server + displayName, never by UUID. Voice example: *"I see two — the Vivarium mister on `pi-krill.local` and the test mister on `pi-krill-05.local`. Which one?"*
    - Empty result → tell the user the phrase didn't match anything in the swarm and stop. Don't speculate-substitute.
 
-   If `find_node` is not available in the session, fall back to: `list_servers` → for each server, `list_nodes type=<inferred>` → match `displayName` against the user's phrase tokens. Apply the same disambiguation rule.
+   If a future/custom session adds a `find_node(query, type?)` helper, you may use it as an optimization, but do **not** assume it exists in v0.0.8. Any such helper should return ranked `(serverId, nodeId)` candidates, and you should still apply the same disambiguation rule above.
 
 2. **Resolve the action.** "Turn on" / "turn off" / "toggle" maps to firing a `KrillApp.Executor.LogicGate` whose `meta.target` is the named Pin or DataPoint. From the resolved target, look up the controlling gate: walk `meta.parent` upward, or `list_nodes type=LogicGate` on the same server and pick the one whose `meta.target` references the resolved node id. "Log a value" / "record" maps to `record_snapshot` directly on the named DataPoint (covered in the next workflow). "Read" / "what is" maps to `get_node` or `read_series`.
 


### PR DESCRIPTION
## Summary

Adds a top-level `SKILL.md` workflow section for natural-language action
requests ("turn on the Vivarium mister") that voice and chat-mode flows
hit constantly. Without it, agents reasoned every step from primitives,
fired wrong-target on close-score candidates, and used `record_snapshot`
as a silent stopgap for `execute_node` (which is still pending in #24) —
polluting the source DataPoint's history without telling the user.

## Approach

- **`krill-mcp/skill/krill/SKILL.md`** — new workflow section *"For
  'natural-language commands → action' (voice or chat-mode requests)"*
  inserted between *"build this tree"* and *"record values"*. Five steps:
  resolve target via a single `find_node` call (with explicit
  ask-the-user thresholds), resolve action by mapping verbs to a
  `LogicGate.meta.target`, **confirm against the *target's*
  `llmSideEffectLevel`, not the executor's** (the gate is `medium`,
  the Pin it writes to is `high`), fire via `execute_node` when
  available else fall back to `record_snapshot` on the gate's source
  DataPoint with a once-per-session "synthetic reading" warning, and
  report by re-reading the target after a 1–2 second delay. Followed
  by an explicit "Failure modes to avoid" list.
- **`krill-mcp-service/src/test/kotlin/.../SkillRulesTest.kt`** — three
  new markdown sanity tests guarding the recipe shape: that the section
  exists, that it spells out the resolve→confirm→fire chain anchored on
  `find_node` and the target's `llmSideEffectLevel`, that
  `execute_node` is named as the preferred fire path, and that the
  "synthetic / pollutes upstream history" warning is present so a
  future cleanup pass can't silently drop the safety caveat.
- **`docs/lessons/2026-04-29-voice-flow-recipe.md`** — root cause
  category (skill-gap: primitives existed, recipe did not) plus
  prevention rules: anchor safety on the target of an action not the
  intermediary; voice flows have a hard ~1-turn confirmation budget;
  document fallbacks with their costs visible.

No upstream relay needed — this is purely a skill-doc gap on
`bsautner/krill-oss`. The underlying primitives (`find_node` from #26,
`record_snapshot`, the `llmSideEffectLevel` catalog) are all already
shipped on this repo's side. The missing `execute_node` tool stays
tracked under #24.

## Introducing commit

Skill-gap, not a regression. The skill never had this recipe — the
voice-flow use case was authored implicitly through the existing
discovery / record / diagram sections, which don't compose into a
voice-friendly chain. `git log -- krill-mcp/skill/krill/SKILL.md`
shows the skill being authored in `71b8957` (initial v0.0.3 add)
without this section, and no later commit attempted to add one.

## Test plan

- [ ] `cd krill-mcp && ./gradlew :krill-mcp-service:test --tests "krill.zone.mcp.skill.SkillRulesTest"` — all four tests pass (one pre-existing + three new).
- [ ] Read the new section in `krill-mcp/skill/krill/SKILL.md` and confirm:
  - Step 1 names `find_node` and the `>=0.9 with clear gap` threshold.
  - Step 3 cross-references the *target's* `llmSideEffectLevel`, not the gate's.
  - Step 4 names `execute_node` as preferred and `record_snapshot` as a stopgap with the synthetic-reading warning.
- [ ] On a live swarm, simulate the Vivarium-mister voice flow against the updated skill: ambiguous phrase → one disambiguating question; high-side-effect target → one confirmation turn before firing.

Closes #27