### PR TITLE
chore(ci): wire CLAUDE_CODE_OAUTH_TOKEN into claude steps

### DIFF
--- a/.github/workflows/Dev Agent Blue.yml
+++ b/.github/workflows/Dev Agent Blue.yml
@@ -74,6 +74,11 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE:  ${{ github.event.issue.title }}
           ISSUE_REPO:   ${{ github.repository }}
+          # Org-wide secret: long-lived OAuth token for `claude --print`
+          # in headless CI. Without this, the CLI falls back to
+          # ~/.claude/.credentials.json on the runner whose 8h subscription
+          # token expires between runs and refresh has been unreliable.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         working-directory: /home/ben/Code/krill-oss
         run: |
           set -euo pipefail

--- a/.github/workflows/Verify Agent Ghost.yml
+++ b/.github/workflows/Verify Agent Ghost.yml
@@ -343,6 +343,11 @@ jobs:
         env:
           ISSUE_REPO: ${{ github.repository }}
           PR_NUMBER:  ${{ github.event.pull_request.number }}
+          # Org-wide secret: long-lived OAuth token for `claude --print`
+          # in headless CI. Without this, launch-tester.sh's claude
+          # sub-process falls back to ~/.claude/.credentials.json on
+          # ghost whose 8h subscription token expires between runs.
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           set -euo pipefail
           set -a


### PR DESCRIPTION
## Summary

Surfaces the org-wide `CLAUDE_CODE_OAUTH_TOKEN` GitHub secret to both workflow steps that run `claude --print`:
- `Run claude dev agent on issue` (Dev Agent Blue.yml)
- `Run ghost QA tester` (Verify Agent Ghost.yml — used by `launch-tester.sh`)

Without it, the CLI falls back to `~/.claude/.credentials.json` on the runner. That file's Claude subscription token expires every ~8h and refresh has been observed unreliable, causing recent QA verify runs to fail with `Failed to authenticate. API Error: 401 Invalid authentication credentials` buried in stderr after a ~30 min build cycle.

## Background

Ben re-authenticated `claude` locally on ghost and set `CLAUDE_CODE_OAUTH_TOKEN` as an org-wide secret. This PR is the YAML wiring — the secret is already provisioned.

## Companion PRs

- Sautner-Studio-LLC/krill-agents#18
- Sautner-Studio-LLC/krill#263

## Test plan

- [x] YAML syntax valid (line additions inside existing `env:` blocks)
- [ ] Real-world: next QA verify / dev-agent run after this lands should auth via the secret.

## Notes

- No `docs/lessons/` entry — this is plumbing for the agent system, not product code.
- This change does not need `needs-qa-verify` (no behavior change in the product itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)