### PR TITLE
added avatar to sdk 0.0.20

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectViewState">
+    <option name="autoscrollToSource" value="true" />
+    <option name="openDirectoriesWithSingleClick" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;settings.editor.selected.configurable&quot;: &quot;AndroidSdkUpdater&quot;
+  }
+}</component>
+</project>

--- a/krill-sdk/build.gradle.kts
+++ b/krill-sdk/build.gradle.kts
@@ -3,6 +3,7 @@
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.SourcesJar
+import org.gradle.internal.execution.caching.CachingState.enabled
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -17,7 +18,7 @@ plugins {
 }
 
 group = "com.krillforge"
-version = "0.0.19"
+version = "0.0.20"
 
 kotlin {
     jvmToolchain(21)

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/KrillApp.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/KrillApp.kt
@@ -148,6 +148,9 @@ fun lookup(name: String): KrillApp? = krillAppLookupMap[name]
 sealed class KrillApp {
 
     @Serializable
+    data object Avatar : KrillApp()
+
+    @Serializable
     data object Client : KrillApp() {
         @Serializable
         data object About : KrillApp()

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/node/NodeFunctions.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/node/NodeFunctions.kt
@@ -12,6 +12,7 @@ import io.ktor.http.Url
 import kotlinx.coroutines.flow.StateFlow
 import krill.zone.shared.KrillApp
 import krill.zone.shared.MenuCommand
+import krill.zone.shared.krillapp.client.ClientMetaData
 import krill.zone.shared.krillapp.datapoint.DataPointMetaData
 import krill.zone.shared.krillapp.datapoint.DataType
 import krill.zone.shared.krillapp.datapoint.graph.GraphMetaData
@@ -70,7 +71,7 @@ fun Node.name(): String {
         KrillApp.DataPoint -> (this.meta as DataPointMetaData).name
         KrillApp.Server.SerialDevice -> (this.meta as SerialDeviceMetaData).hardwareId
         KrillApp.Server, KrillApp.Server.Peer -> (this.meta as ServerMetaData).name
-        KrillApp.Client -> (this.meta as krill.zone.shared.krillapp.client.ClientMetaData).name
+        KrillApp.Client -> (this.meta as ClientMetaData).name
         KrillApp.Server.Pin -> (this.meta as PinMetaData).name
         KrillApp.DataPoint.Graph -> (this.meta as GraphMetaData).name.ifEmpty { "Graph" }
         KrillApp.Project.TaskList -> (this.meta as TaskListMetaData).name


### PR DESCRIPTION
<!--
PR template for Sautner-Studio-LLC/krill-oss. The dev agent's CLAUDE.md mandates
this shape — keep all four sections, even if a section is one line.

`Closes #<n>` is mandatory. CI rejects PRs without a lesson entry under
`docs/lessons/YYYY-MM-DD-<slug>.md`.
-->

## Summary

<!-- 1–3 sentences. What changed and why, from the user's POV. Avoid restating the issue title. -->

## Approach

<!-- The how. Bullet the file-level changes; pick option-vs-option if you considered alternatives. Include any cross-repo escalation (filed Sautner-Studio-LLC/krill#<m>?). -->

## Introducing commit

<!-- `git log -S '<symbol>'` result that introduced the bug, plus a one-line summary. If genuinely cannot find one (e.g. predates this repo's history), say "predates split from Sautner-Studio-LLC/krill" and link the QA issue's evidence. -->

## Test plan

<!-- Checkboxes the reviewer can run. Include the gradle command, a single-test selector if relevant, and any out-of-CI verification (live swarm probe, Maven local install, etc.). -->

- [ ] `./gradlew ...`
- [ ] <regression test the QA agent should reproduce on a live swarm>

Closes #<issue>

<!-- Add `@qa-agent please verify` as a separate comment after the PR opens, not inline here — it's a request to act, not part of the PR description. -->
