### PR TITLE
updated tasklist to support TargetingNodeMetaData

### DIFF
--- a/krill-sdk/local.properties
+++ b/krill-sdk/local.properties
@@ -1,1 +1,8 @@
-sdk.dir=/home/ben/Android/Sdk
+## This file must *NOT* be checked into Version Control Systems,
+# as it contains information specific to your local configuration.
+#
+# Location of the SDK. This is only used by Gradle.
+# For customization when using a Version Control System, please read the
+# header note.
+#Thu May 14 11:04:45 EDT 2026
+sdk.dir=/home/ben/sdk

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/tasklist/TaskListMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/tasklist/TaskListMetaData.kt
@@ -7,7 +7,10 @@
 package krill.zone.shared.krillapp.project.tasklist
 
 import kotlinx.serialization.*
+import krill.zone.shared.node.ExecutionSource
+import krill.zone.shared.node.NodeIdentity
 import krill.zone.shared.node.NodeMetaData
+import krill.zone.shared.node.TargetingNodeMetaData
 
 /**
  * Payload for a `Project.TaskList` node.
@@ -27,4 +30,7 @@ data class TaskListMetaData(
     /** Epoch millis of the most recent edit (any task add/remove/edit or metadata change). */
     val updatedAt: Long = 0L,
     override val error: String = "",
-) : NodeMetaData
+    override val sources: List<NodeIdentity>,
+    override val targets: List<NodeIdentity>,
+    override val executionSource: List<ExecutionSource>,
+) : TargetingNodeMetaData


### PR DESCRIPTION
<!--
PR template for Sautner-Studio-LLC/krill-oss. The dev agent's CLAUDE.md mandates
this shape — keep all four sections, even if a section is one line.

`Closes #<n>` is mandatory. CI rejects PRs without a lesson entry under
`docs/lessons/YYYY-MM-DD-<slug>.md`.
-->

## Summary

<!-- 1–3 sentences. What changed and why, from the user's POV. Avoid restating the issue title. -->

## Approach

<!-- The how. Bullet the file-level changes; pick option-vs-option if you considered alternatives. Include any cross-repo escalation (filed Sautner-Studio-LLC/krill#<m>?). -->

## Introducing commit

<!-- `git log -S '<symbol>'` result that introduced the bug, plus a one-line summary. If genuinely cannot find one (e.g. predates this repo's history), say "predates split from Sautner-Studio-LLC/krill" and link the QA issue's evidence. -->

## Test plan

<!-- Checkboxes the reviewer can run. Include the gradle command, a single-test selector if relevant, and any out-of-CI verification (live swarm probe, Maven local install, etc.). -->

- [ ] `./gradlew ...`
- [ ] <regression test the QA agent should reproduce on a live swarm>

Closes #<issue>

<!-- Add `@qa-agent please verify` as a separate comment after the PR opens, not inline here — it's a request to act, not part of the PR description. -->
