### PR TITLE
remove targets from sdk in favor of all nodes storing snapshots of th…

### DIFF
--- a/krill-sdk/build.gradle.kts
+++ b/krill-sdk/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "com.krillforge"
-version = "0.0.28"
+version = "0.0.29"
 
 kotlin {
     jvmToolchain(21)

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/client/ClientMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/client/ClientMetaData.kt
@@ -7,10 +7,11 @@
 package krill.zone.shared.krillapp.client
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Client` node.
@@ -27,7 +28,7 @@ data class ClientMetaData(
     val logging: Boolean = false,
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/datapoint/DataPointMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/datapoint/DataPointMetaData.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.*
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 import kotlin.time.*
 
 /**
@@ -26,7 +26,7 @@ data class DataPointMetaData @OptIn(ExperimentalTime::class) constructor(
      */
     val sourceId: String = "",
     /** Most recent observation. Defaults to a "now, 0.0" placeholder so graphs render cleanly. */
-    val snapshot: Snapshot = Snapshot(Clock.System.now().epochSeconds, 0.0),
+
     /** Number of decimal places the editor renders [Snapshot.value] with. */
     val precision: Int = 2,
     /** Free-form units string (`"°C"`, `"%"`, `"V"`) appended to display values. */
@@ -41,7 +41,7 @@ data class DataPointMetaData @OptIn(ExperimentalTime::class) constructor(
     val path: String = "",
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(Clock.System.now().epochSeconds, 0.0),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/datapoint/filter/FilterMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/datapoint/filter/FilterMetaData.kt
@@ -9,10 +9,11 @@
 package krill.zone.shared.krillapp.datapoint.filter
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for any `DataPoint.Filter` node — a name and a single numeric
@@ -24,7 +25,7 @@ data class FilterMetaData(
     val value: Double = 0.0,
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/datapoint/graph/GraphMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/datapoint/graph/GraphMetaData.kt
@@ -8,16 +8,17 @@
 package krill.zone.shared.krillapp.datapoint.graph
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.krillapp.executor.compute.ComputeTimeRange
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `DataPoint.Graph` node.
  *
- * Implements [TargetingNodeMetaData] for consistency with the other
+ * Implements [SourceMetaData] for consistency with the other
  * source-bound node types, but only [sources] is meaningful — graphs read
  * data, they don't write it. [targets] is kept empty.
  */
@@ -31,11 +32,11 @@ data class GraphMetaData(
      */
     val name: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    /** Not used for graphs but required by the [TargetingNodeMetaData] contract. */
-    override val targets: List<NodeIdentity> = emptyList(),
+    /** Not used for graphs but required by the [SourceMetaData] contract. */
+    override val snapshot: Snapshot = Snapshot(),
     /** Lookback window the graph displays — drives the X-axis range. */
     val timeRange: ComputeTimeRange = ComputeTimeRange.HOUR,
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/ExecutorMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/ExecutorMetaData.kt
@@ -13,10 +13,11 @@ package krill.zone.shared.krillapp.executor
 
 import kotlinx.serialization.*
 import krill.zone.shared.KrillApp
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for the generic `Executor` node.
@@ -30,7 +31,7 @@ data class ExecuteMetaData(
     val source: String = "",
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/calculation/CalculationEngineNodeMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/calculation/CalculationEngineNodeMetaData.kt
@@ -12,7 +12,7 @@ import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Calculation` executor node.
@@ -20,7 +20,7 @@ import krill.zone.shared.node.TargetingNodeMetaData
 @Serializable
 data class CalculationEngineNodeMetaData(
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     /** Display name; defaults to the class's simple name on creation. */
     val name: String = this::class.simpleName!!,
     /** Free-form formula string evaluated by the server's calculation engine. */
@@ -39,4 +39,4 @@ data class CalculationEngineNodeMetaData(
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/compute/ComputeMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/compute/ComputeMetaData.kt
@@ -6,10 +6,11 @@
 package krill.zone.shared.krillapp.executor.compute
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Compute` executor node.
@@ -17,7 +18,7 @@ import krill.zone.shared.node.TargetingNodeMetaData
 @Serializable
 data class ComputeMetaData(
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     /** Lookback window the operation applies over. `NONE` means "use the whole series". */
     val range: ComputeTimeRange = ComputeTimeRange.NONE,
     /** Aggregation reduction to apply to the windowed snapshots. */
@@ -25,4 +26,4 @@ data class ComputeMetaData(
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/lambda/LambdaSourceMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/lambda/LambdaSourceMetaData.kt
@@ -9,10 +9,11 @@
 package krill.zone.shared.krillapp.executor.lambda
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Lambda` executor node.
@@ -20,7 +21,7 @@ import krill.zone.shared.node.TargetingNodeMetaData
 @Serializable
 data class LambdaSourceMetaData(
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     /** User-supplied tag/value pairs; passed through to the script as environment-style data. */
     val tags: Map<String, String> = emptyMap(),
     /** Filename of the uploaded `.py` source on the server (e.g. `"average.py"`). */
@@ -30,4 +31,4 @@ data class LambdaSourceMetaData(
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/logicgate/LogicGateMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/logicgate/LogicGateMetaData.kt
@@ -7,10 +7,11 @@
 package krill.zone.shared.krillapp.executor.logicgate
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `LogicGate` executor node.
@@ -26,8 +27,8 @@ data class LogicGateMetaData(
     val gateType: LogicGate = LogicGate.BUFFER,
     val inputs: Pair<NodeIdentity?, NodeIdentity?> = Pair(null, null),
     override val sources: List<NodeIdentity> = listOf(NodeIdentity("", "")),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/mqtt/MqttMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/mqtt/MqttMetaData.kt
@@ -6,10 +6,11 @@
 package krill.zone.shared.krillapp.executor.mqtt
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Direction of the MQTT executor.
@@ -28,7 +29,7 @@ enum class MqttAction {
 @Serializable
 data class MqttMetaData(
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     /** Broker address (host:port or URI). */
     val address: String = "",
     /** Topic pattern to publish to or subscribe from. */
@@ -39,4 +40,4 @@ data class MqttMetaData(
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/smtp/SMTPMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/smtp/SMTPMetaData.kt
@@ -6,10 +6,11 @@
 package krill.zone.shared.krillapp.executor.smtp
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for an `SMTP` executor node.
@@ -29,8 +30,8 @@ data class SMTPMetaData(
     /** `To:` address(es) — comma-separated list. */
     val toAddress: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/webhook/WebHookOutMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/webhook/WebHookOutMetaData.kt
@@ -7,10 +7,12 @@ package krill.zone.shared.krillapp.executor.webhook
 
 import kotlinx.serialization.*
 import krill.zone.shared.io.HttpMethod
+import krill.zone.shared.krillapp.datapoint.Snapshot
+import krill.zone.shared.krillapp.datapoint.Snapshot.Companion.invoke
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for an `OutgoingWebHook` executor node.
@@ -19,8 +21,7 @@ import krill.zone.shared.node.TargetingNodeMetaData
 data class WebHookOutMetaData(
     val name: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
-    /** Full target URL, including scheme. */
+
     val url: String = "",
     /** HTTP verb to use — defaults to `GET`. */
     val method: HttpMethod = HttpMethod.GET,
@@ -35,7 +36,8 @@ data class WebHookOutMetaData(
      * [params].
      */
     val headers: List<Pair<String, String>> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/ProjectMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/ProjectMetaData.kt
@@ -6,10 +6,11 @@
 package krill.zone.shared.krillapp.project
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Project` node — the user-facing display name plus an
@@ -21,7 +22,7 @@ data class ProjectMetaData(
     val description: String = "",
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/camera/CameraMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/camera/CameraMetaData.kt
@@ -6,10 +6,11 @@
 package krill.zone.shared.krillapp.project.camera
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Camera` node — the editable capture configuration and an
@@ -31,7 +32,7 @@ data class CameraMetaData(
     val enabled: Boolean = true,
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/diagram/DiagramMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/diagram/DiagramMetaData.kt
@@ -7,10 +7,11 @@
 package krill.zone.shared.krillapp.project.diagram
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Diagram` node.
@@ -30,7 +31,7 @@ data class DiagramMetaData(
     val anchorBindings: Map<String, String> = emptyMap(),
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/journal/JournalMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/journal/JournalMetaData.kt
@@ -6,10 +6,11 @@
 package krill.zone.shared.krillapp.project.journal
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Project.Journal` node.
@@ -28,7 +29,7 @@ data class JournalMetaData(
     val updatedAt: Long = 0L,
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/tasklist/TaskListMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/tasklist/TaskListMetaData.kt
@@ -7,10 +7,11 @@
 package krill.zone.shared.krillapp.project.tasklist
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Project.TaskList` node.
@@ -31,7 +32,7 @@ data class TaskListMetaData(
     val updatedAt: Long = 0L,
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/ServerMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/ServerMetaData.kt
@@ -15,10 +15,11 @@ package krill.zone.shared.krillapp.server
 
 import kotlinx.serialization.*
 import krill.zone.shared.Platform
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Server` (or `Server.Peer`) node.
@@ -55,10 +56,10 @@ data class ServerMetaData(
     val cameraAvailable: Boolean = false,
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData {
+) : SourceMetaData {
 
     /**
      * Returns a resolvable hostname for this server.

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/backup/BackupMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/backup/BackupMetaData.kt
@@ -11,10 +11,11 @@
 package krill.zone.shared.krillapp.server.backup
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Server.Backup` node.
@@ -39,7 +40,7 @@ data class BackupMetaData(
     @Transient val restoreFile: String = "",
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/llm/LLMMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/llm/LLMMetaData.kt
@@ -7,10 +7,11 @@
 package krill.zone.shared.krillapp.server.llm
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Server.LLM` node.
@@ -33,7 +34,7 @@ data class LLMMetaData(
     val selectedNodes: List<NodeIdentity> = emptyList(),
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/pin/PinMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/pin/PinMetaData.kt
@@ -8,12 +8,13 @@
 package krill.zone.shared.krillapp.server.pin
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.krillapp.server.*
 import krill.zone.shared.node.DigitalState
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Server.Pin` node.
@@ -44,10 +45,10 @@ data class PinMetaData(
     val color: String? = null,
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData {
+) : SourceMetaData {
     /**
      * `true` when the pin has been assigned a real header position and a
      * non-default hardware id. Unconfigured defaults (`pinNumber == 0` and

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/serialdevice/SerialDeviceMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/serialdevice/SerialDeviceMetaData.kt
@@ -8,12 +8,13 @@
 package krill.zone.shared.krillapp.server.serialdevice
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.krillapp.server.HardwareType
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
 import krill.zone.shared.node.NodeState
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Server.SerialDevice` node.
@@ -28,7 +29,7 @@ data class SerialDeviceMetaData(
     /** Hardware classification — always `SERIAL` for this node type. */
     val hardwareType: HardwareType = HardwareType.SERIAL,
     /** Lifecycle state of the underlying jSerialComm port. */
-    val status: NodeState = NodeState.CREATED,
+    val status: NodeState = NodeState.CREATE_OR_OVERWRITE,
 
     /** Polling interval for `READ` operations, in milliseconds. */
     val interval: Long = 5000L,
@@ -65,8 +66,8 @@ data class SerialDeviceMetaData(
     val sendCommand: String = "R",
 
     override val sources: List<NodeIdentity> = listOf(NodeIdentity("", "")),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/serialdevice/SerialDeviceTargetMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/serialdevice/SerialDeviceTargetMetaData.kt
@@ -6,10 +6,11 @@
 package krill.zone.shared.krillapp.server.serialdevice
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for the auxiliary "serial-device-target" node type that wraps a
@@ -25,7 +26,7 @@ data class SerialDeviceTargetMetaData(
     val value: String = "",
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/spacer/SpacerMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/spacer/SpacerMetaData.kt
@@ -6,10 +6,11 @@
 package krill.zone.shared.krillapp.spacer
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Spacer` node. Carries only a display [name] (so the user
@@ -20,7 +21,7 @@ data class SpacerMetaData(
     val name: String = "spacer",
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/TriggerMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/TriggerMetaData.kt
@@ -7,10 +7,11 @@
 package krill.zone.shared.krillapp.trigger
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for the simple-threshold trigger family.
@@ -30,6 +31,6 @@ data class TriggerMetaData(
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/button/ButtonMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/button/ButtonMetaData.kt
@@ -7,10 +7,11 @@
 package krill.zone.shared.krillapp.trigger.button
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /** Payload for a `Button` trigger — display name plus the standard error field. */
 @Serializable
@@ -19,6 +20,6 @@ data class ButtonMetaData(
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/color/ColorTriggerMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/color/ColorTriggerMetaData.kt
@@ -10,10 +10,11 @@
 package krill.zone.shared.krillapp.trigger.color
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `Color` trigger.
@@ -37,9 +38,9 @@ data class ColorTriggerMetaData(
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
-) : TargetingNodeMetaData {
+) : SourceMetaData {
     /**
      * Returns the centre of the configured RGB bounding box as a packed ARGB
      * `Long` (`0xFFRRGGBB`) suitable for use as a Compose colour. Used by the

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/cron/CronMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/cron/CronMetaData.kt
@@ -7,10 +7,11 @@
 package krill.zone.shared.krillapp.trigger.cron
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for a `CronTimer` trigger node.
@@ -26,6 +27,6 @@ data class CronMetaData(
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
-    override val targets: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/webhook/IncomingWebHookMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/webhook/IncomingWebHookMetaData.kt
@@ -7,10 +7,11 @@ package krill.zone.shared.krillapp.trigger.webhook
 
 import kotlinx.serialization.*
 import krill.zone.shared.io.HttpMethod
+import krill.zone.shared.krillapp.datapoint.Snapshot
 import krill.zone.shared.node.ExecutionSource
 import krill.zone.shared.node.NodeAction
 import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.TargetingNodeMetaData
+import krill.zone.shared.node.SourceMetaData
 
 /**
  * Payload for an `IncomingWebHook` trigger node.
@@ -26,26 +27,12 @@ data class IncomingWebHookMetaData(
     val name: String = "",
     /** URL path the server exposes for this hook (e.g. `"/webhook/garage-open"`). */
     val path: String = "",
-    @Deprecated(
-        "Use targets instead",
-        replaceWith = ReplaceWith("targets.firstOrNull()?.nodeId ?: \"\""),
-    )
-    val target: String = "",
+
     /** HTTP verb the trigger accepts — defaults to `GET`. */
     val method: HttpMethod = HttpMethod.GET,
     override val sources: List<NodeIdentity> = emptyList(),
-    @Suppress("DEPRECATION")
-    override val targets: List<NodeIdentity> = if (target.isNotEmpty()) {
-        if (target.contains(":")) {
-            val parts = target.split(":")
-            listOf(NodeIdentity(parts.last(), parts.first()))
-        } else {
-            listOf(NodeIdentity(target, ""))
-        }
-    } else {
-        emptyList()
-    },
+    override val snapshot: Snapshot = Snapshot(),
     override val executionSource: List<ExecutionSource> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
-) : TargetingNodeMetaData
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/node/NodeFunctions.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/node/NodeFunctions.kt
@@ -17,6 +17,7 @@ import krill.zone.shared.krillapp.datapoint.DataPointMetaData
 import krill.zone.shared.krillapp.datapoint.DataType
 import krill.zone.shared.krillapp.datapoint.graph.GraphMetaData
 import krill.zone.shared.krillapp.executor.lambda.LambdaSourceMetaData
+import krill.zone.shared.krillapp.executor.logicgate.LogicGateMetaData
 import krill.zone.shared.krillapp.project.ProjectMetaData
 import krill.zone.shared.krillapp.project.camera.CameraMetaData
 import krill.zone.shared.krillapp.project.diagram.DiagramMetaData
@@ -50,7 +51,7 @@ fun Node.key(): String = "${this.timestamp}:${this.id}"
 
 /**
  * Returns this node's address pair — `(nodeId, hostId)` — as a
- * [NodeIdentity] suitable for use inside [TargetingNodeMetaData] source /
+ * [NodeIdentity] suitable for use inside [SourceMetaData] source /
  * target lists.
  */
 fun Node.id(): NodeIdentity = NodeIdentity(
@@ -80,6 +81,7 @@ fun Node.name(): String {
         KrillApp.Server.Backup -> (this.meta as BackupMetaData).name.ifEmpty { "Backup" }
         KrillApp.Project -> (this.meta as ProjectMetaData).name
         KrillApp.Project.Diagram -> (this.meta as DiagramMetaData).name
+        KrillApp.Executor.LogicGate -> (this.meta as LogicGateMetaData).name.ifEmpty { this.meta.gateType.name }
         KrillApp.Executor.Lambda -> {
             val meta = this.meta as LambdaSourceMetaData
             if (meta.filename.isNotEmpty()) meta.filename.removeSuffix(".py") else ""

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/node/NodeMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/node/NodeMetaData.kt
@@ -1,7 +1,7 @@
 /**
  * Public contracts for the per-node payload (`meta`) that every Krill node
  * carries. The interface ([NodeMetaData]) and the cross-node addressing types
- * ([NodeIdentity], [TargetingNodeMetaData], [ExecutionSource], [NodeAction],
+ * ([NodeIdentity], [SourceMetaData], [ExecutionSource], [NodeAction],
  * [ActionNodeMetaData]) live in the SDK so external integrators can implement
  * their own node types and link them into a Krill swarm without depending on
  * the proprietary metadata implementations that ship with the reference server.
@@ -14,6 +14,7 @@
 package krill.zone.shared.node
 
 import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.Snapshot
 
 /**
  * Marker interface that every node's per-type metadata payload must implement.
@@ -40,7 +41,7 @@ interface NodeMetaData {
 /**
  * Address pair that uniquely identifies a node in a multi-server Krill swarm.
  *
- * Used inside [TargetingNodeMetaData.sources] / [TargetingNodeMetaData.targets]
+ * Used inside [SourceMetaData.sources] / [SourceMetaData.targets]
  * so callers never have to parse a `"host:id"` string back into its components.
  *
  * `@Serializable` because the type rides inside polymorphic node payloads and
@@ -66,7 +67,7 @@ data class NodeIdentity(
  * The set of events that can cause an executor / filter / trigger node to
  * fire its work.
  *
- * Stored as a `List<ExecutionSource>` on [TargetingNodeMetaData] so a single
+ * Stored as a `List<ExecutionSource>` on [SourceMetaData] so a single
  * node can opt into multiple firing modes simultaneously (e.g. fire when the
  * source DataPoint changes **and** when the user clicks the node chip).
  *
@@ -108,7 +109,7 @@ enum class NodeAction(val displayLabel: String) {
  * Extended contract for trigger and executor metadata that carries an explicit
  * [nodeAction] discriminator.
  *
- * Applying this interface to the trigger-family and [TargetingNodeMetaData]
+ * Applying this interface to the trigger-family and [SourceMetaData]
  * hierarchy lets the server processor and the editor UI branch on action
  * without per-type `when` arms. The default on every concrete implementation
  * is [NodeAction.EXECUTE], preserving wire-compatibility with pre-0.0.23
@@ -137,24 +138,21 @@ interface ActionNodeMetaData : NodeMetaData {
  * (cycle detection, dependency graphing, propagation) walk the swarm without
  * caring which subtype it is on.
  */
-interface TargetingNodeMetaData : ActionNodeMetaData {
+interface SourceMetaData : ActionNodeMetaData {
     /**
      * Upstream nodes whose values feed this one. For a filter or executor this
      * is the data being read; for a trigger it is the value being watched.
      */
     val sources: List<NodeIdentity>
-
-    /**
-     * Downstream nodes this one writes to or actuates. May be empty for nodes
-     * that only side-effect outside the swarm (e.g. an SMTP executor).
-     */
-    @Deprecated("nodes no longer write to targets, data is pulled from sources.")
-    val targets: List<NodeIdentity>
-
-    /**
+     /**
      * The set of [ExecutionSource]s configured to wake this node. The node
      * processor checks the incoming event against this list before doing any
      * work. An empty list means "never auto-fire" — only manual execution.
      */
     val executionSource: List<ExecutionSource>
+
+    /**
+     * Stores the last result of when this node was invoked and is a source of data
+     */
+    val snapshot : Snapshot
 }

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/node/NodeState.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/node/NodeState.kt
@@ -88,8 +88,8 @@ enum class NodeState {
     /** The node is in the middle of being deleted; shown briefly so clients can animate the removal. */
     DELETING,
 
-    /** The node was just created; shown briefly to allow the UI to fade it in. */
-    CREATED,
+    /** The node was just created; shown briefly to allow the UI to fade it in, or it changed in a way where it needs to be completely refreshed */
+    CREATE_OR_OVERWRITE,
 
     /** The user has opened the node in the editor but has not yet submitted changes. */
     USER_EDIT,

--- a/krill-sdk/src/commonTest/kotlin/krill/zone/shared/node/NodeActionTest.kt
+++ b/krill-sdk/src/commonTest/kotlin/krill/zone/shared/node/NodeActionTest.kt
@@ -33,14 +33,14 @@ class NodeActionTest {
 
     @Test
     fun `SMTPMetaData without nodeAction field deserialises as EXECUTE`() {
-        val json = """{"host":"smtp.example.com","port":587,"username":"","token":"","fromAddress":"","toAddress":"","sources":[],"targets":[],"executionSource":[],"error":""}"""
+        val json = """{"host":"smtp.example.com","port":587,"username":"","token":"","fromAddress":"","toAddress":"","sources":[],"executionSource":[],"error":""}"""
         val meta = Json.decodeFromString(SMTPMetaData.serializer(), json)
         assertEquals(NodeAction.EXECUTE, meta.nodeAction)
     }
 
     @Test
     fun `LogicGateMetaData without nodeAction field deserialises as EXECUTE`() {
-        val json = """{"name":"logic gate","gateType":"BUFFER","sources":[{"nodeId":"","hostId":""}],"targets":[],"executionSource":[],"error":""}"""
+        val json = """{"name":"logic gate","gateType":"BUFFER","sources":[{"nodeId":"","hostId":""}],"executionSource":[],"error":""}"""
         val meta = Json.decodeFromString(LogicGateMetaData.serializer(), json)
         assertEquals(NodeAction.EXECUTE, meta.nodeAction)
     }

--- a/krill-sdk/src/commonTest/kotlin/krill/zone/shared/node/SourceVerbWiringTest.kt
+++ b/krill-sdk/src/commonTest/kotlin/krill/zone/shared/node/SourceVerbWiringTest.kt
@@ -32,7 +32,7 @@ import kotlin.test.assertTrue
  * Covers:
  *  - the dispatch contract that carries the originating [NodeIdentity] +
  *    its verb to a woken receiver ([SourceTriggerPayload]);
- *  - universal [TargetingNodeMetaData] across every shipped MetaData type;
+ *  - universal [SourceMetaData] across every shipped MetaData type;
  *  - back-compat: payloads predating this change deserialise with safe
  *    defaults (empty wiring, [NodeAction.EXECUTE]).
  */
@@ -83,7 +83,7 @@ class SourceVerbWiringTest {
     // ---- D3: every shipped MetaData type is a TargetingNodeMetaData ----
 
     /** One pre-change payload per newly-targeting type (absent wiring + verb). */
-    private val preChangePayloads: Map<String, TargetingNodeMetaData> = mapOf(
+    private val preChangePayloads: Map<String, SourceMetaData> = mapOf(
         "ClientMetaData" to dec(ClientMetaData.serializer(), """{"name":"ui"}"""),
         "DataPointMetaData" to dec(DataPointMetaData.serializer(), """{"name":"dp"}"""),
         "DiagramMetaData" to dec(DiagramMetaData.serializer(), """{"name":"d"}"""),
@@ -118,7 +118,6 @@ class SourceVerbWiringTest {
     fun `pre-change payloads deserialise with safe wiring defaults`() {
         for ((name, meta) in preChangePayloads) {
             assertTrue(meta.sources.isEmpty(), "$name.sources should default empty")
-            assertTrue(meta.targets.isEmpty(), "$name.targets should default empty")
             assertTrue(meta.executionSource.isEmpty(), "$name.executionSource should default empty")
             assertEquals(NodeAction.EXECUTE, meta.nodeAction, "$name.nodeAction should default EXECUTE")
         }
@@ -130,7 +129,7 @@ class SourceVerbWiringTest {
         val meta = PinMetaData(
             name = "relay",
             sources = listOf(src),
-            targets = listOf(NodeIdentity("dp-2", "host-a")),
+
             executionSource = listOf(ExecutionSource.SOURCE_VALUE_MODIFIED),
             nodeAction = NodeAction.RESET,
         )


### PR DESCRIPTION
…eir last invokation

<!--
PR template for Sautner-Studio-LLC/krill-oss. The dev agent's CLAUDE.md mandates
this shape — keep all four sections, even if a section is one line.

`Closes #<n>` is mandatory. CI rejects PRs without a lesson entry under
`docs/lessons/YYYY-MM-DD-<slug>.md`.
-->

## Summary

<!-- 1–3 sentences. What changed and why, from the user's POV. Avoid restating the issue title. -->

## Approach

<!-- The how. Bullet the file-level changes; pick option-vs-option if you considered alternatives. Include any cross-repo escalation (filed Sautner-Studio-LLC/krill#<m>?). -->

## Introducing commit

<!-- `git log -S '<symbol>'` result that introduced the bug, plus a one-line summary. If genuinely cannot find one (e.g. predates this repo's history), say "predates split from Sautner-Studio-LLC/krill" and link the QA issue's evidence. -->

## Test plan

<!-- Checkboxes the reviewer can run. Include the gradle command, a single-test selector if relevant, and any out-of-CI verification (live swarm probe, Maven local install, etc.). -->

- [ ] `./gradlew ...`
- [ ] <regression test the QA agent should reproduce on a live swarm>

Closes #<issue>

<!-- Add `@qa-agent please verify` as a separate comment after the PR opens, not inline here — it's a request to act, not part of the PR description. -->
