### PR TITLE
krill sdk 0.0.33 - ensure nodes use inputs and snapshots for processing

### DIFF
--- a/krill-sdk/build.gradle.kts
+++ b/krill-sdk/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "com.krillforge"
-version = "0.0.32"
+version = "0.0.33"
 
 kotlin {
     jvmToolchain(21)

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/ExecutorMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/ExecutorMetaData.kt
@@ -12,12 +12,9 @@
 package krill.zone.shared.krillapp.executor
 
 import kotlinx.serialization.*
-import krill.zone.shared.KrillApp
-import krill.zone.shared.krillapp.datapoint.Snapshot
-import krill.zone.shared.node.InvocationTrigger
-import krill.zone.shared.node.NodeAction
-import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.SourceMetaData
+import krill.zone.shared.*
+import krill.zone.shared.krillapp.datapoint.*
+import krill.zone.shared.node.*
 
 /**
  * Payload for the generic `Executor` node.
@@ -27,12 +24,11 @@ data class ExecuteMetaData(
     val name: String,
     /** Optional [KrillApp] discriminator used by the editor to filter wireable source types. */
     val sourceType: KrillApp? = null,
-    /** Free-form source identifier — typically a node id, but may be a path or scheme-specific string. */
-    val source: String = "",
+
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
     override val snapshot: Snapshot = Snapshot(),
     override val invocationTriggers: List<InvocationTrigger> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-override val inputs: List<NodeIdentity> = emptyList(),
+    override val inputs: List<NodeIdentity> = emptyList(),
 ) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/calculation/CalculationEngineNodeMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/calculation/CalculationEngineNodeMetaData.kt
@@ -17,7 +17,7 @@ import krill.zone.shared.node.*
 @Serializable
 data class CalculationEngineNodeMetaData(
     override val sources: List<NodeIdentity> = emptyList(),
-    override val snapshot: Snapshot = Snapshot(),
+
     /** Display name; defaults to the class's simple name on creation. */
     val name: String = this::class.simpleName!!,
     /** Free-form formula string evaluated by the server's calculation engine. */
@@ -32,7 +32,7 @@ data class CalculationEngineNodeMetaData(
      * Last computed value + timestamp. The readable output a DataPoint
      * subscriber pulls when this calc wakes it. `null` until first compute.
      */
-    val derived: Snapshot? = null,
+    override val snapshot: Snapshot = Snapshot(),
     override val invocationTriggers: List<InvocationTrigger> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/serialdevice/SerialDeviceMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/serialdevice/SerialDeviceMetaData.kt
@@ -8,13 +8,9 @@
 package krill.zone.shared.krillapp.server.serialdevice
 
 import kotlinx.serialization.*
-import krill.zone.shared.krillapp.datapoint.Snapshot
-import krill.zone.shared.krillapp.server.HardwareType
-import krill.zone.shared.node.InvocationTrigger
-import krill.zone.shared.node.NodeAction
-import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.NodeState
-import krill.zone.shared.node.SourceMetaData
+import krill.zone.shared.krillapp.datapoint.*
+import krill.zone.shared.krillapp.server.*
+import krill.zone.shared.node.*
 
 /**
  * Payload for a `Server.SerialDevice` node.
@@ -70,5 +66,5 @@ data class SerialDeviceMetaData(
     override val invocationTriggers: List<InvocationTrigger> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
     override val error: String = "",
-override val inputs: List<NodeIdentity> = emptyList(),
+    override val inputs: List<NodeIdentity> = emptyList(),
 ) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/spacer/SpacerMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/spacer/SpacerMetaData.kt
@@ -6,11 +6,8 @@
 package krill.zone.shared.krillapp.spacer
 
 import kotlinx.serialization.*
-import krill.zone.shared.krillapp.datapoint.Snapshot
-import krill.zone.shared.node.InvocationTrigger
-import krill.zone.shared.node.NodeAction
-import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.SourceMetaData
+import krill.zone.shared.krillapp.datapoint.*
+import krill.zone.shared.node.*
 
 /**
  * Payload for a `Spacer` node. Carries only a display [name] (so the user
@@ -24,5 +21,5 @@ data class SpacerMetaData(
     override val snapshot: Snapshot = Snapshot(),
     override val invocationTriggers: List<InvocationTrigger> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-override val inputs: List<NodeIdentity> = emptyList(),
+    override val inputs: List<NodeIdentity> = emptyList(),
 ) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/button/ButtonMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/button/ButtonMetaData.kt
@@ -7,11 +7,8 @@
 package krill.zone.shared.krillapp.trigger.button
 
 import kotlinx.serialization.*
-import krill.zone.shared.krillapp.datapoint.Snapshot
-import krill.zone.shared.node.InvocationTrigger
-import krill.zone.shared.node.NodeAction
-import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.SourceMetaData
+import krill.zone.shared.krillapp.datapoint.*
+import krill.zone.shared.node.*
 
 /** Payload for a `Button` trigger — display name plus the standard error field. */
 @Serializable
@@ -22,5 +19,5 @@ data class ButtonMetaData(
     override val sources: List<NodeIdentity> = emptyList(),
     override val snapshot: Snapshot = Snapshot(),
     override val invocationTriggers: List<InvocationTrigger> = emptyList(),
-override val inputs: List<NodeIdentity> = emptyList(),
+    override val inputs: List<NodeIdentity> = emptyList(),
 ) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/color/ColorTriggerMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/color/ColorTriggerMetaData.kt
@@ -10,11 +10,8 @@
 package krill.zone.shared.krillapp.trigger.color
 
 import kotlinx.serialization.*
-import krill.zone.shared.krillapp.datapoint.Snapshot
-import krill.zone.shared.node.InvocationTrigger
-import krill.zone.shared.node.NodeAction
-import krill.zone.shared.node.NodeIdentity
-import krill.zone.shared.node.SourceMetaData
+import krill.zone.shared.krillapp.datapoint.*
+import krill.zone.shared.node.*
 
 /**
  * Payload for a `Color` trigger.
@@ -40,7 +37,7 @@ data class ColorTriggerMetaData(
     override val sources: List<NodeIdentity> = emptyList(),
     override val snapshot: Snapshot = Snapshot(),
     override val invocationTriggers: List<InvocationTrigger> = emptyList(),
-override val inputs: List<NodeIdentity> = emptyList(),
+    override val inputs: List<NodeIdentity> = emptyList(),
 ) : SourceMetaData {
     /**
      * Returns the centre of the configured RGB bounding box as a packed ARGB


### PR DESCRIPTION
<!--
PR template for Sautner-Studio-LLC/krill-oss. The dev agent's CLAUDE.md mandates
this shape — keep all four sections, even if a section is one line.

`Closes #<n>` is mandatory. CI rejects PRs without a lesson entry under
`docs/lessons/YYYY-MM-DD-<slug>.md`.
-->

## Summary

<!-- 1–3 sentences. What changed and why, from the user's POV. Avoid restating the issue title. -->

## Approach

<!-- The how. Bullet the file-level changes; pick option-vs-option if you considered alternatives. Include any cross-repo escalation (filed Sautner-Studio-LLC/krill#<m>?). -->

## Introducing commit

<!-- `git log -S '<symbol>'` result that introduced the bug, plus a one-line summary. If genuinely cannot find one (e.g. predates this repo's history), say "predates split from Sautner-Studio-LLC/krill" and link the QA issue's evidence. -->

## Test plan

<!-- Checkboxes the reviewer can run. Include the gradle command, a single-test selector if relevant, and any out-of-CI verification (live swarm probe, Maven local install, etc.). -->

- [ ] `./gradlew ...`
- [ ] <regression test the QA agent should reproduce on a live swarm>

Closes #<issue>

<!-- Add `@qa-agent please verify` as a separate comment after the PR opens, not inline here — it's a request to act, not part of the PR description. -->
