### PR TITLE
atted timer node type

### DIFF
--- a/krill-sdk/build.gradle.kts
+++ b/krill-sdk/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "com.krillforge"
-version = "0.0.36"
+version = "0.0.37"
 
 kotlin {
     jvmToolchain(21)

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/KrillApp.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/KrillApp.kt
@@ -249,6 +249,10 @@ sealed class KrillApp {
         data object CronTimer : KrillApp()
 
         @Serializable
+        data object Timer : KrillApp()
+
+
+        @Serializable
         data object SilentAlarmMs : KrillApp()
 
         @Serializable

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/timer/TimerMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/timer/TimerMetaData.kt
@@ -1,0 +1,30 @@
+/**
+ * Metadata for the `Timer` trigger — a node that fires once
+ * when invoked, can be REST or EXCUTED by an observed node; the
+ * [CronMetaData.timestamp] field is updated by the server each time the
+ * trigger fires so clients can render "last fired" without a separate query.
+ */
+package krill.zone.shared.krillapp.trigger.timer
+
+import kotlinx.serialization.*
+import krill.zone.shared.krillapp.datapoint.*
+import krill.zone.shared.node.*
+
+/**
+ * Payload for a `Timer` trigger node.
+ */
+@Serializable
+data class TimerMetaData(
+    /** Display name shown in the editor and on the node chip. */
+    val name: String,
+    /** Epoch millis of the most recent fire — `0` if the trigger has not fired yet. */
+    val timestamp: Long = 0L,
+    /** time to wait  */
+    val delay: Long = 1000L,
+    override val nodeAction: NodeAction = NodeAction.EXECUTE,
+    override val error: String = "",
+    override val sources: List<NodeIdentity> = emptyList(),
+    override val snapshot: Snapshot = Snapshot(),
+    override val invocationTriggers: List<InvocationTrigger> = emptyList(),
+    override val inputs: List<NodeIdentity> = emptyList(),
+) : SourceMetaData

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/node/NodeMetaDataUpdate.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/node/NodeMetaDataUpdate.kt
@@ -27,6 +27,7 @@ import krill.zone.shared.krillapp.trigger.*
 import krill.zone.shared.krillapp.trigger.button.*
 import krill.zone.shared.krillapp.trigger.color.*
 import krill.zone.shared.krillapp.trigger.cron.*
+import krill.zone.shared.krillapp.trigger.timer.TimerMetaData
 import krill.zone.shared.krillapp.trigger.webhook.*
 
 /**
@@ -68,6 +69,7 @@ fun updateMetaWithError(meta: NodeMetaData, error: String): NodeMetaData {
         is CameraMetaData -> meta.copy(error = error)
         is BackupMetaData -> meta.copy(error = error)
         is ColorTriggerMetaData -> meta.copy(error = error)
+        is TimerMetaData -> meta.copy(error = error)
         else -> meta
     }
 }


### PR DESCRIPTION
<!--
PR template for Sautner-Studio-LLC/krill-oss. The dev agent's CLAUDE.md mandates
this shape — keep all four sections, even if a section is one line.

`Closes #<n>` is mandatory. CI rejects PRs without a lesson entry under
`docs/lessons/YYYY-MM-DD-<slug>.md`.
-->

## Summary

<!-- 1–3 sentences. What changed and why, from the user's POV. Avoid restating the issue title. -->

## Approach

<!-- The how. Bullet the file-level changes; pick option-vs-option if you considered alternatives. Include any cross-repo escalation (filed Sautner-Studio-LLC/krill#<m>?). -->

## Introducing commit

<!-- `git log -S '<symbol>'` result that introduced the bug, plus a one-line summary. If genuinely cannot find one (e.g. predates this repo's history), say "predates split from Sautner-Studio-LLC/krill" and link the QA issue's evidence. -->

## Test plan

<!-- Checkboxes the reviewer can run. Include the gradle command, a single-test selector if relevant, and any out-of-CI verification (live swarm probe, Maven local install, etc.). -->

- [ ] `./gradlew ...`
- [ ] <regression test the QA agent should reproduce on a live swarm>

Closes #<issue>

<!-- Add `@qa-agent please verify` as a separate comment after the PR opens, not inline here — it's a request to act, not part of the PR description. -->
