### PR TITLE
Add propagation metadata (epoch, hopTtl) to SourceTriggerPayload

### DIFF
--- a/krill-sdk/build.gradle.kts
+++ b/krill-sdk/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "com.krillforge"
-version = "0.0.38"
+version = "0.0.39"
 
 kotlin {
     jvmToolchain(21)

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/events/SourceTriggerPayload.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/events/SourceTriggerPayload.kt
@@ -1,6 +1,6 @@
 /**
  * Payload for a `SOURCE_TRIGGERED` [Event] — the cross-server SSE transport
- * contract that carries a source-change notification to a remote receiver.
+ * contract that carries a source-change notification to remote receivers.
  *
  * Under the unified source-owned-verb model the verb applied is the
  * *originating* node's [krill.zone.shared.node.NodeAction], not the
@@ -9,6 +9,28 @@
  * this payload; the receiver's processor reads the source's current value
  * (locally, or from the value-bearing `PIN_CHANGED` / `SNAPSHOT_UPDATE`
  * event that accompanies the change) and decides what to do.
+ *
+ * ## Broadcast, not targeted push (observer model)
+ *
+ * The originating host emits this payload onto its general `/events` stream
+ * for **every** subscriber — it does not address, or even know, which remote
+ * nodes observe the source. A remote host receives it only because it
+ * *subscribed* (its `PeerObservationClient` opened the stream because a local
+ * node lists a source on the originating host). This keeps cross-server
+ * delivery a pull/observe relationship: the observer's host listens, the
+ * source's host just announces.
+ *
+ * ## Propagation metadata (cycle bounding)
+ *
+ * [epoch] and [hopTtl] carry the cross-server propagation context:
+ *  - [epoch] — the originating host's monotonic propagation token, so a
+ *    receiver can dedupe a payload re-delivered by SSE retransmit/reconnect
+ *    within one logical propagation. Defaults to `0` for payloads that
+ *    predate the field.
+ *  - [hopTtl] — decremented at each host boundary; at `0` the receiver
+ *    updates local state but SHALL NOT start a further outbound propagation,
+ *    bounding cross-host cycles (`A → B → A → …`). Defaults to
+ *    [DEFAULT_HOP_TTL]; legitimate cross-server chains are short.
  *
  * ## Local dispatch rule
  *
@@ -29,10 +51,12 @@ import krill.zone.shared.node.NodeIdentity
 
 /**
  * Identifies the node that just changed and the verb it owns, delivered to
- * every node that lists it as a source with a firing `executionSource`.
+ * every node that lists it as a source with a firing `invocationTrigger`.
  *
  * [nodeAction] defaults to [NodeAction.EXECUTE] so a payload that predates
- * the field (or omits it) yields the original forward behaviour.
+ * the field (or omits it) yields the original forward behaviour. [epoch] and
+ * [hopTtl] default so that a pre-propagation-metadata payload deserialises to
+ * a safe "fresh propagation, full TTL budget" value.
  */
 @Serializable
 data class SourceTriggerPayload(
@@ -40,4 +64,25 @@ data class SourceTriggerPayload(
     val triggeringSource: NodeIdentity,
     /** The originating node's durable verb — applied by the receiver, not its own. */
     val nodeAction: NodeAction = NodeAction.EXECUTE,
-) : EventPayload
+    /**
+     * Originating host's monotonic propagation token. Lets a receiver dedupe
+     * an SSE-redelivered payload within one logical propagation. `0` for
+     * payloads predating this field.
+     */
+    val epoch: Long = 0L,
+    /**
+     * Remaining cross-host hops. Decremented at each host boundary; at `0`
+     * the receiver updates local state but does not re-propagate outward,
+     * bounding cross-server cycles. Defaults to [DEFAULT_HOP_TTL].
+     */
+    val hopTtl: Int = DEFAULT_HOP_TTL,
+) : EventPayload {
+    companion object {
+        /**
+         * Default cross-host hop budget for a fresh propagation. Generous —
+         * legitimate cross-server source chains are short; the bound exists to
+         * stop a misconfigured cycle from storming the swarm.
+         */
+        const val DEFAULT_HOP_TTL: Int = 16
+    }
+}

--- a/krill-sdk/src/commonTest/kotlin/krill/zone/shared/node/SourceVerbWiringTest.kt
+++ b/krill-sdk/src/commonTest/kotlin/krill/zone/shared/node/SourceVerbWiringTest.kt
@@ -80,6 +80,32 @@ class SourceVerbWiringTest {
         assertEquals(NodeAction.EXECUTE, decoded.nodeAction)
     }
 
+    // ---- Phase 5 (observer-flow-collector-dispatch): propagation metadata ----
+
+    @Test
+    fun `SourceTriggerPayload defaults epoch 0 and full hop TTL when absent`() {
+        // A payload predating the propagation-metadata fields must deserialise
+        // to "fresh propagation, full budget" so cross-server delivery is safe.
+        val json = """{"triggeringSource":{"nodeId":"n","hostId":"h"}}"""
+        val decoded = Json.decodeFromString(SourceTriggerPayload.serializer(), json)
+        assertEquals(0L, decoded.epoch)
+        assertEquals(SourceTriggerPayload.DEFAULT_HOP_TTL, decoded.hopTtl)
+    }
+
+    @Test
+    fun `SourceTriggerPayload carries epoch and hop TTL when present`() {
+        val origin = NodeIdentity(nodeId = "n", hostId = "h")
+        val payload = SourceTriggerPayload(origin, NodeAction.EXECUTE, epoch = 42L, hopTtl = 3)
+        val decoded = Json.decodeFromString(
+            SourceTriggerPayload.serializer(),
+            Json.encodeToString(SourceTriggerPayload.serializer(), payload),
+        )
+        assertEquals(42L, decoded.epoch)
+        assertEquals(3, decoded.hopTtl)
+        assertEquals(origin, decoded.triggeringSource)
+        assertEquals(NodeAction.EXECUTE, decoded.nodeAction)
+    }
+
     // ---- D3: every shipped MetaData type is a TargetingNodeMetaData ----
 
     /** One pre-change payload per newly-targeting type (absent wiring + verb). */


### PR DESCRIPTION
## Summary

Add `epoch` and `hopTtl` fields to `SourceTriggerPayload` to track cross-server propagation context and prevent cycles in multi-host source chains. These fields enable deduplication of SSE-redelivered payloads and bound hop count to stop misconfigured cycles. Both fields default to safe values for backward compatibility with pre-metadata payloads.

## Approach

- **`krill-sdk/src/commonMain/kotlin/krill/zone/shared/events/SourceTriggerPayload.kt`**
  - Added `epoch: Long = 0L` — originating host's monotonic propagation token for SSE retransmit/reconnect deduplication within one logical propagation.
  - Added `hopTtl: Int = DEFAULT_HOP_TTL` — remaining cross-host hops; decremented at each boundary; at `0` the receiver updates local state but does not re-propagate, bounding cycles.
  - Added companion constant `DEFAULT_HOP_TTL = 16` — generous default for fresh propagations; legitimate cross-server chains are short.
  - Expanded KDoc with two new sections: "Broadcast, not targeted push (observer model)" and "Propagation metadata (cycle bounding)" to document the observer pattern and cycle-prevention semantics.
  - Updated field references in existing KDoc (`executionSource` → `invocationTrigger`).

- **`krill-sdk/src/commonTest/kotlin/krill/zone/shared/node/SourceVerbWiringTest.kt`**
  - Added `SourceTriggerPayload defaults epoch 0 and full hop TTL when absent` — verifies backward compatibility: pre-metadata payloads deserialize to "fresh propagation, full budget".
  - Added `SourceTriggerPayload carries epoch and hop TTL when present` — verifies round-trip serialization of both new fields.

- **`krill-sdk/build.gradle.kts`**
  - Bumped version `0.0.38` → `0.0.39` (required by `krill-sdk` module policy for Maven Central dispatch).

## Introducing commit

Predates this repo's history; feature addition for cross-server cycle prevention in source-triggered propagation.

## Test plan

- [x] `./gradlew krill-sdk:test` — new tests verify backward compatibility (absent fields) and round-trip serialization (present fields).

Closes #<issue>

https://claude.ai/code/session_01FHjgd5Lb8P4fQYpa1ZUySB