### PR TITLE
Add KRILL_KRAKEN_ROOT to workflow environment variables

### DIFF
--- a/.github/workflows/Dev Agent Blue.yml
+++ b/.github/workflows/Dev Agent Blue.yml
@@ -30,6 +30,7 @@ jobs:
       KRILL_REPO_DIR:    /home/ben/Code/krill
       KRILL_OSS_DIR:     /home/ben/Code/krill-oss
       KRILL_AGENTS_ROOT: /home/ben/Code/krill-agents
+      KRILL_KRAKEN_ROOT: /home/ben/Code/kraken
 
     steps:
       # ── 1. Sync the three working copies (fetch always; ff-pull main if safe) ─
@@ -37,7 +38,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          for dir in "$KRILL_REPO_DIR" "$KRILL_OSS_DIR" "$KRILL_AGENTS_ROOT"; do
+          for dir in "$KRILL_REPO_DIR" "$KRILL_OSS_DIR" "$KRILL_AGENTS_ROOT" "KRILL_KRAKEN_ROOT"; do
             if [[ ! -d "$dir/.git" ]]; then
               echo "❌ $dir is not a git working copy" >&2
               exit 1
@@ -50,8 +51,9 @@ jobs:
           update_repo "$KRILL_REPO_DIR"
           update_repo "$KRILL_OSS_DIR"
           update_repo "$KRILL_AGENTS_ROOT"
+          update_repo "$KRILL_KRAKEN_ROOT"
 
-          for dir in "$KRILL_REPO_DIR" "$KRILL_OSS_DIR" "$KRILL_AGENTS_ROOT"; do
+          for dir in "$KRILL_REPO_DIR" "$KRILL_OSS_DIR" "$KRILL_AGENTS_ROOT" "KRILL_KRAKEN_ROOT"; do
             branch="$(git -C "$dir" rev-parse --abbrev-ref HEAD)"
             sha="$(git -C "$dir" rev-parse --short HEAD)"
             echo "  $dir → $branch @ $sha"
@@ -98,6 +100,7 @@ jobs:
           echo "   Working dir : $KRILL_OSS_DIR"
           echo "   krill (ref) : $KRILL_REPO_DIR"
           echo "   krill-agents: $KRILL_AGENTS_ROOT"
+          echo "   krill-agents: $KRILL_KRAKEN_ROOT"
           echo "   claude      : $CLAUDE_BIN"
 
           "$CLAUDE_BIN" --print --dangerously-skip-permissions \


### PR DESCRIPTION
<!--
PR template for Sautner-Studio-LLC/krill-oss. The dev agent's CLAUDE.md mandates
this shape — keep all four sections, even if a section is one line.

`Closes #<n>` is mandatory. CI rejects PRs without a lesson entry under
`docs/lessons/YYYY-MM-DD-<slug>.md`.
-->

## Summary

<!-- 1–3 sentences. What changed and why, from the user's POV. Avoid restating the issue title. -->

## Approach

<!-- The how. Bullet the file-level changes; pick option-vs-option if you considered alternatives. Include any cross-repo escalation (filed Sautner-Studio-LLC/krill#<m>?). -->

## Introducing commit

<!-- `git log -S '<symbol>'` result that introduced the bug, plus a one-line summary. If genuinely cannot find one (e.g. predates this repo's history), say "predates split from Sautner-Studio-LLC/krill" and link the QA issue's evidence. -->

## Test plan

<!-- Checkboxes the reviewer can run. Include the gradle command, a single-test selector if relevant, and any out-of-CI verification (live swarm probe, Maven local install, etc.). -->

- [ ] `./gradlew ...`
- [ ] <regression test the QA agent should reproduce on a live swarm>

Closes #<issue>

<!-- Add `@qa-agent please verify` as a separate comment after the PR opens, not inline here — it's a request to act, not part of the PR description. -->
