### PR TITLE
removed idle trigger in favor of using countdown timers

### DIFF
--- a/krill-sdk/build.gradle.kts
+++ b/krill-sdk/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "com.krillforge"
-version = "0.0.41"
+version = "0.0.42"
 
 kotlin {
     jvmToolchain(21)

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/KrillApp.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/KrillApp.kt
@@ -89,7 +89,6 @@ val krillAppChildren: Map<KrillApp?, List<KrillApp>> = mapOf(
         KrillApp.Trigger.Button,
         KrillApp.Trigger.CronTimer,
         KrillApp.Trigger.Timer,
-        KrillApp.Trigger.SilentAlarmMs,
         KrillApp.Trigger.HighThreshold,
         KrillApp.Trigger.LowThreshold,
         KrillApp.Trigger.IncomingWebHook,
@@ -251,10 +250,6 @@ sealed class KrillApp {
 
         @Serializable
         data object Timer : KrillApp()
-
-
-        @Serializable
-        data object SilentAlarmMs : KrillApp()
 
         @Serializable
         data object HighThreshold : KrillApp()

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/datapoint/DataPointRelevance.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/datapoint/DataPointRelevance.kt
@@ -40,25 +40,27 @@ object DataPointRelevance {
 
     /**
      * Returns the [KrillApp] trigger subtypes that are meaningful for a
-     * DataPoint of the given [dataType]. `SilentAlarmMs` shows up across
+     * DataPoint of the given [dataType]. `Timer` shows up across
      * most types because "haven't seen a value in X ms" is a universally
-     * useful health check.
+     * useful health check using it as a countdown timer to fire if not reset.
      */
     fun relevantTriggers(dataType: DataType): List<KrillApp> = when (dataType) {
         DataType.DOUBLE -> listOf(
             KrillApp.Trigger.HighThreshold,
             KrillApp.Trigger.LowThreshold,
-            KrillApp.Trigger.SilentAlarmMs,
+            KrillApp.Trigger.Timer
         )
         DataType.COLOR -> listOf(
             KrillApp.Trigger.Color,
-            KrillApp.Trigger.SilentAlarmMs,
+            KrillApp.Trigger.Timer
         )
         DataType.DIGITAL -> listOf(
-            KrillApp.Trigger.SilentAlarmMs,
+            KrillApp.Trigger.Timer
         )
         DataType.TEXT,
-        DataType.JSON -> emptyList()
+        DataType.JSON -> listOf(
+            KrillApp.Trigger.Timer
+        )
     }
 
     /** `true` if [app] appears in [relevantFilters] for [dataType]. */

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/TriggerMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/trigger/TriggerMetaData.kt
@@ -1,6 +1,6 @@
 /**
  * Default metadata for generic numeric-threshold triggers
- * (`SilentAlarmMs`, `HighThreshold`, `LowThreshold`). Each subtype shares the
+ * (`HighThreshold`, `LowThreshold`). Each subtype shares the
  * same shape — a name and a configured threshold value — so a single
  * data class powers all of them.
  */
@@ -15,8 +15,7 @@ import krill.zone.shared.node.*
  *
  * The interpretation of [value] depends on the [krill.zone.shared.KrillApp]
  * subclass the node is wearing: for `HighThreshold` it is the upper bound,
- * for `LowThreshold` the lower bound, for `SilentAlarmMs` the silence
- * duration in milliseconds.
+ * for `LowThreshold` the lower bound
  *
  * Default [name] uses the class's `simpleName` so a brand-new node already
  * has a sensible label without the user editing anything.


### PR DESCRIPTION
<!--
PR template for Sautner-Studio-LLC/krill-oss. The dev agent's CLAUDE.md mandates
this shape — keep all four sections, even if a section is one line.

`Closes #<n>` is mandatory. CI rejects PRs without a lesson entry under
`docs/lessons/YYYY-MM-DD-<slug>.md`.
-->

## Summary

<!-- 1–3 sentences. What changed and why, from the user's POV. Avoid restating the issue title. -->

## Approach

<!-- The how. Bullet the file-level changes; pick option-vs-option if you considered alternatives. Include any cross-repo escalation (filed Sautner-Studio-LLC/krill#<m>?). -->

## Introducing commit

<!-- `git log -S '<symbol>'` result that introduced the bug, plus a one-line summary. If genuinely cannot find one (e.g. predates this repo's history), say "predates split from Sautner-Studio-LLC/krill" and link the QA issue's evidence. -->

## Test plan

<!-- Checkboxes the reviewer can run. Include the gradle command, a single-test selector if relevant, and any out-of-CI verification (live swarm probe, Maven local install, etc.). -->

- [ ] `./gradlew ...`
- [ ] <regression test the QA agent should reproduce on a live swarm>

Closes #<issue>

<!-- Add `@qa-agent please verify` as a separate comment after the PR opens, not inline here — it's a request to act, not part of the PR description. -->
