### PR TITLE
fix(krill-mcp): ship the krill-mcp-token script advertised by postinst

### DIFF
--- a/.github/workflows/Verify Agent Ghost.yml
+++ b/.github/workflows/Verify Agent Ghost.yml
@@ -267,6 +267,7 @@ jobs:
                     krill-mcp-service/package/DEBIAN/prerm \
                     krill-mcp-service/package/DEBIAN/postrm
           chmod 755 krill-mcp-service/package/usr/local/bin/krill-mcp.jar
+          chmod 755 krill-mcp-service/package/usr/local/bin/krill-mcp-token
           mkdir -p krill-mcp-service/build
           dpkg-deb --build krill-mcp-service/package krill-mcp-service/build/krill-mcp.deb
           echo "📦 $(dpkg-deb --field krill-mcp-service/build/krill-mcp.deb Package Version)"

--- a/docs/lessons/2026-06-12-krill-mcp-token-never-shipped.md
+++ b/docs/lessons/2026-06-12-krill-mcp-token-never-shipped.md
@@ -1,0 +1,47 @@
+# `krill-mcp-token` advertised everywhere but never shipped
+
+**Issue:** none — reported directly by Ben (command not found on a prod install)
+**Root cause category:** Packaging — gitignore silently swallowed a deb payload script
+**Module:** `krill-mcp`
+
+## What happened
+
+The krill-mcp deb's `postinst` banner, `DEPLOYMENT.md`, `SKILL.md`,
+`references/mcp-tools.md`, and two krill-repo blog posts all instruct users to
+run `sudo krill-mcp-token` to reprint the Claude connector URL + bearer token.
+The script never existed: from the original packaging commit (`3770ea9`),
+`DEPLOYMENT.md` included a `chmod 755 .../usr/local/bin/krill-mcp-token` step,
+but no such file was ever committed. The likely cause is `krill-mcp/.gitignore`'s
+generic Eclipse `bin/` pattern, which matches `package/usr/local/bin/` and
+silently ignored the script. The production `Deploy Debian Repo.yml` (krill
+repo) then dropped the chmod line — presumably because it failed on the missing
+file — so every shipped deb advertised a command it didn't contain.
+
+## Fix
+
+- `krill-mcp/krill-mcp-service/package/usr/local/bin/krill-mcp-token`: new
+  POSIX sh script that reprints the postinst banner (connector URLs + bearer).
+  Reads `/etc/krill-mcp/credentials/pin_derived_key` and the `listenPort` from
+  `/etc/krill-mcp/config.json` (default 50052); paths are env-overridable
+  (`KRILL_MCP_KEY_FILE`, `KRILL_MCP_CONFIG_FILE`) so it can be exercised
+  against fixtures without touching production paths.
+- `krill-mcp/.gitignore`: un-ignore `krill-mcp-service/package/usr/local/bin/`
+  while keeping the build-time-copied `krill-mcp.jar` ignored.
+- `.github/workflows/Verify Agent Ghost.yml`: chmod the script in the deb
+  build step, matching `DEPLOYMENT.md`.
+- krill repo (separate change): restored the same chmod line in
+  `Deploy Debian Repo.yml`.
+
+## Prevention
+
+- **Never document a command before the file exists in the tree.** If a
+  postinst banner or doc names an executable, `git ls-files` must show it.
+- **Audit generic IDE gitignore patterns (`bin/`, `out/`, `build/`) against
+  deb payload trees.** `package/usr/local/bin/` is payload, not build output;
+  a template gitignore can silently drop shipped files. `git status` showing
+  clean is not proof a new file was added — use `git check-ignore -v` when a
+  payload path overlaps a common ignore name.
+- **A failing build step is a signal, not an obstacle.** The production
+  workflow omitting `DEPLOYMENT.md`'s chmod line hid the missing file instead
+  of surfacing it. When a documented build step fails, fix the cause rather
+  than deleting the step.

--- a/krill-mcp/.gitignore
+++ b/krill-mcp/.gitignore
@@ -30,6 +30,10 @@ out/
 bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
+# The deb payload dir is named bin/ — keep the shipped token script tracked,
+# but not the fat JAR the deploy workflow copies in at build time.
+!krill-mcp-service/package/usr/local/bin/
+krill-mcp-service/package/usr/local/bin/krill-mcp.jar
 
 ### NetBeans ###
 /nbproject/private/

--- a/krill-mcp/krill-mcp-service/package/usr/local/bin/krill-mcp-token
+++ b/krill-mcp/krill-mcp-service/package/usr/local/bin/krill-mcp-token
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Reprint the krill-mcp connector URL + bearer token shown by postinst.
+# The key file is root-readable only, so this is normally run as:
+#   sudo krill-mcp-token
+
+set -e
+
+KEY_FILE="${KRILL_MCP_KEY_FILE:-/etc/krill-mcp/credentials/pin_derived_key}"
+CONFIG_FILE="${KRILL_MCP_CONFIG_FILE:-/etc/krill-mcp/config.json}"
+
+if [ ! -e "$KEY_FILE" ] && [ ! -L "$KEY_FILE" ]; then
+    echo "krill-mcp-token: $KEY_FILE not found — is krill-mcp installed and configured?" >&2
+    exit 1
+fi
+
+if [ ! -r "$KEY_FILE" ]; then
+    echo "krill-mcp-token: cannot read $KEY_FILE — run with sudo." >&2
+    exit 1
+fi
+
+BEARER=$(cat "$KEY_FILE")
+LISTEN_PORT=$(awk -F'[ ,:]+' '/listenPort/{for(i=1;i<=NF;i++) if($i ~ /^[0-9]+$/){print $i; exit}}' "$CONFIG_FILE" 2>/dev/null || true)
+[ -n "$LISTEN_PORT" ] || LISTEN_PORT=50052
+HOSTNAME=$(hostname)
+HOST_IP=$(hostname -I 2>/dev/null | awk '{print $1}')
+
+echo ""
+echo "🦐 krill-mcp connector credentials"
+echo ""
+echo "Add a Custom Connector in Claude with:"
+echo "   URL:    http://$HOSTNAME.local:$LISTEN_PORT/mcp"
+echo "   (or)    http://$HOSTNAME:$LISTEN_PORT/mcp"
+if [ -n "$HOST_IP" ]; then
+    echo "   (or)    http://$HOST_IP:$LISTEN_PORT/mcp"
+fi
+echo "   Header: Authorization: Bearer $BEARER"
+echo ""


### PR DESCRIPTION
## Summary

`sudo krill-mcp-token` is documented in the postinst banner, `DEPLOYMENT.md`, `SKILL.md`, `references/mcp-tools.md`, and two krill blog posts, but prod installs get "command not found" — the script was never committed, so no deb ever contained it. This PR adds the actual script so every documented reference becomes correct without editing the docs.

## Approach

- `krill-mcp/krill-mcp-service/package/usr/local/bin/krill-mcp-token` — new POSIX sh script that reprints the postinst banner: connector URLs (hostname.local / hostname / IP, port read from `/etc/krill-mcp/config.json`, default 50052) plus the bearer from the key file. Distinct errors for "not installed" vs "run with sudo". Key/config paths are env-overridable (`KRILL_MCP_KEY_FILE`, `KRILL_MCP_CONFIG_FILE`) so it can be exercised against fixtures without touching production paths.
- `krill-mcp/.gitignore` — root cause: the generic Eclipse `bin/` pattern matched `package/usr/local/bin/` and silently swallowed the script from day one. Carved out `!krill-mcp-service/package/usr/local/bin/` while keeping the build-time-copied `krill-mcp.jar` ignored.
- `.github/workflows/Verify Agent Ghost.yml` — chmod the script in the deb build step, matching `DEPLOYMENT.md` line 50.
- Cross-repo: companion PR on `Sautner-Studio-LLC/krill` restores the same chmod in `Deploy Debian Repo.yml`. **Merge this PR first** — the krill deploy workflow's chmod fails until this script exists in the krill-oss working copy.

## Introducing commit

`3770ea9` — "create claude code mcp service deb package" (2026-04-19). `DEPLOYMENT.md` referenced the chmod for the script from the start, but the file itself was never committed (gitignored).

## Test plan

- [x] `sh -n` syntax check passes.
- [x] All four paths exercised against fixture files via env overrides: happy path prints URL + bearer; missing config falls back to port 50052; missing key exits 1 with "is krill-mcp installed"; unreadable key exits 1 with "run with sudo".
- [x] Test deb built with the exact workflow steps; `dpkg-deb --contents` shows `-rwxr-xr-x ./usr/local/bin/krill-mcp-token`.
- [x] `git check-ignore -v` confirms the script is tracked and `krill-mcp.jar` stays ignored.
- [x] Exec bit committed (`git ls-files --stage` → 100755).

Skipping `needs-qa-verify` — runtime change but not MCP-verifiable: the fix is a host-side CLI script with no MCP tool that observes it; verified via deb contents + fixture-path runs above. @bsautner for review.

Closes — no issue; reported directly by Ben in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)