### PR TITLE
chore(krill-mcp): complete the 0.0.11 version bump (control + SERVER_VERSION + skill)

### DIFF
--- a/krill-mcp/krill-mcp-service/package/DEBIAN/control
+++ b/krill-mcp/krill-mcp-service/package/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: krill-mcp
-Version: 0.0.10
+Version: 0.0.11
 Section: utils
 Priority: optional
 Architecture: all

--- a/krill-mcp/krill-mcp-service/src/main/kotlin/krill/zone/mcp/Main.kt
+++ b/krill-mcp/krill-mcp-service/src/main/kotlin/krill/zone/mcp/Main.kt
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 
 private val log = LoggerFactory.getLogger("krill-mcp")
 
-private const val SERVER_VERSION = "0.0.10"
+private const val SERVER_VERSION = "0.0.11"
 
 fun main() {
     log.info("Starting krill-mcp version={}", SERVER_VERSION)

--- a/krill-mcp/skill/krill/SKILL.md
+++ b/krill-mcp/skill/krill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: krill
-version: 0.0.10
+version: 0.0.11
 description: Use when working with a Krill swarm — the home-automation/IoT system whose nodes are reachable via the krill-mcp Model Context Protocol server (typically http://<host>:50052/mcp, see https://krillswarm.com). Invoke for discovering or inspecting Krill servers, nodes, DataPoints, Triggers, Filters, Executors, Pins, or peers; reading time-series sensor data; reasoning about which node type to use for a given automation; and authoring, uploading, downloading, and improving SVG dashboards (Diagram nodes) that overlay live node state on a custom layout. Triggers on keywords like krill, swarm, krill server, krill node, krill-mcp, DataPoint, Trigger threshold, SVG dashboard, k_ anchor, swarm sensor, pi-krill, create project, create diagram, improve diagram.
 ---
 


### PR DESCRIPTION
## Summary

The `0.0.10 → 0.0.11` bump (4c06d06) only touched `build.gradle.kts`. The other version-sync sites stayed at 0.0.10 — which is why deploying "0.0.11" to kraken was a silent no-op.

## Diagnosis (live, on kraken via SSH)

- `apt-cache policy krill-mcp` → `Installed: 0.0.10  Candidate: 0.0.10` from `deb.krill.zone` — **no 0.0.11 in the repo to upgrade to**.
- Running jar `/usr/local/bin/krill-mcp.jar`: mtime **2026-06-10**, baked version string **0.0.10**; service last started 2026-06-12. Nothing was replaced.
- `list_node_types` still emits the pre-fix schema (`targets`/`executionSource`).

Root cause: `DEBIAN/control` `Version:` was still `0.0.10`, so any rebuilt deb is published as 0.0.10 and apt never sees an upgrade. `Main.kt SERVER_VERSION` was also still `0.0.10`, so even a correctly-deployed fix would self-report 0.0.10 via `initialize`.

## Approach

- `krill-mcp-service/package/DEBIAN/control`: `Version: 0.0.10 → 0.0.11`
- `krill-mcp-service/.../Main.kt`: `SERVER_VERSION "0.0.10" → "0.0.11"`
- `skill/krill/SKILL.md`: frontmatter `version: 0.0.10 → 0.0.11`

`build.gradle.kts` was already 0.0.11. Historical `v0.0.10` prose references (e.g. "Since v0.0.10 every node carries nodeAction") are left intact — they record when a feature landed.

## Introducing commit

- SHA: `4c06d06` — "Bump version from 0.0.10 to 0.0.11" (bumped only `build.gradle.kts`).

## Test plan

- [x] `grep -rn '0.0.10' krill-mcp/krill-mcp-service/package/DEBIAN/control krill-mcp/.../Main.kt` — no version-line hits remain
- [ ] After merge + rebuild: deb publishes as 0.0.11; on kraken `apt update && apt install --only-upgrade krill-mcp` installs it and restarts the service
- [ ] `initialize` → `serverInfo.version` reports `0.0.11`; `list_node_types` shows `sources`/`inputs`/`invocationTriggers`; the Counter/Calculation/CronTimer exercise then runs end-to-end via MCP

Skipping `needs-qa-verify` — version-string only; the runtime fix it unblocks is in already-merged #135, and Ghost can't observe a deb rebuild from MCP. Ben owns the kraken deploy.

Refs #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)