### PR TITLE
fixing version numbers in claude mcp skill

### DIFF
--- a/krill-mcp/krill-mcp-service/package/DEBIAN/control
+++ b/krill-mcp/krill-mcp-service/package/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: krill-mcp
-Version: 0.0.10
+Version: 0.0.11
 Section: utils
 Priority: optional
 Architecture: all

--- a/krill-mcp/krill-mcp-service/src/main/kotlin/krill/zone/mcp/Main.kt
+++ b/krill-mcp/krill-mcp-service/src/main/kotlin/krill/zone/mcp/Main.kt
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 
 private val log = LoggerFactory.getLogger("krill-mcp")
 
-private const val SERVER_VERSION = "0.0.10"
+private const val SERVER_VERSION = "0.0.11"
 
 fun main() {
     log.info("Starting krill-mcp version={}", SERVER_VERSION)

--- a/krill-mcp/skill/krill/SKILL.md
+++ b/krill-mcp/skill/krill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: krill
-version: 0.0.10
+version: 0.0.11
 description: Use when working with a Krill swarm — the home-automation/IoT system whose nodes are reachable via the krill-mcp Model Context Protocol server (typically http://<host>:50052/mcp, see https://krillswarm.com). Invoke for discovering or inspecting Krill servers, nodes, DataPoints, Triggers, Filters, Executors, Pins, or peers; reading time-series sensor data; reasoning about which node type to use for a given automation; and authoring, uploading, downloading, and improving SVG dashboards (Diagram nodes) that overlay live node state on a custom layout. Triggers on keywords like krill, swarm, krill server, krill node, krill-mcp, DataPoint, Trigger threshold, SVG dashboard, k_ anchor, swarm sensor, pi-krill, create project, create diagram, improve diagram.
 ---
 
@@ -30,7 +30,7 @@ Example — a counter that increments every 5 seconds: a CronTimer fires on sche
 
 ## When to invoke
 
-- The user mentions a Krill swarm, a specific Krill server (e.g. `pi-krill-05.local`), or any Krill node type by name.
+- The user mentions a Krill swarm, a specific Krill server (e.g. `kraken.local`), or any Krill node type by name, or uses the word "Krill" in a sentence.
 - The user wants to see what sensors / nodes exist, read a value, or understand a trigger or executor's current state.
 - The user wants a visual dashboard built on top of their swarm — almost always means a `KrillApp.Project.Diagram` SVG.
 - The user asks "what kind of node should I use to ..." — answer from the bundled node-type catalog instead of guessing.

--- a/krill-mcp/skill/krill/references/mcp-tools.md
+++ b/krill-mcp/skill/krill/references/mcp-tools.md
@@ -253,7 +253,7 @@ Set only the action verb on any Krill node. Prefer `set_node_wiring` when also s
 | `EXECUTE` | (default) Observers run their primary execution logic. |
 | `RESET` | Observers revert to initial/cleared state: TaskList marks all tasks complete and reopens repeatables; Trigger family (HighThreshold, LowThreshold, SilentAlarmMs, Color) transitions WARN→NONE without re-evaluating the threshold. A node with no sensible response to a verb safely ignores it (best effort). |
 
-Since v0.0.10, every node type carries `nodeAction` (all MetaData implements `ActionNodeMetaData`). Read via `get_node` → `meta.nodeAction`.
+Since v0.0.11, every node type carries `nodeAction` (all MetaData implements `ActionNodeMetaData`). Read via `get_node` → `meta.nodeAction`.
 
 ```json
 {"name": "set_node_action", "arguments": {"server": "<optional>", "id": "<node-uuid>", "action": "RESET"}}


### PR DESCRIPTION
<!--
PR template for Sautner-Studio-LLC/krill-oss. The dev agent's CLAUDE.md mandates
this shape — keep all four sections, even if a section is one line.

`Closes #<n>` is mandatory. CI rejects PRs without a lesson entry under
`docs/lessons/YYYY-MM-DD-<slug>.md`.
-->

## Summary

<!-- 1–3 sentences. What changed and why, from the user's POV. Avoid restating the issue title. -->

## Approach

<!-- The how. Bullet the file-level changes; pick option-vs-option if you considered alternatives. Include any cross-repo escalation (filed Sautner-Studio-LLC/krill#<m>?). -->

## Introducing commit

<!-- `git log -S '<symbol>'` result that introduced the bug, plus a one-line summary. If genuinely cannot find one (e.g. predates this repo's history), say "predates split from Sautner-Studio-LLC/krill" and link the QA issue's evidence. -->

## Test plan

<!-- Checkboxes the reviewer can run. Include the gradle command, a single-test selector if relevant, and any out-of-CI verification (live swarm probe, Maven local install, etc.). -->

- [ ] `./gradlew ...`
- [ ] <regression test the QA agent should reproduce on a live swarm>

Closes #<issue>

<!-- Add `@qa-agent please verify` as a separate comment after the PR opens, not inline here — it's a request to act, not part of the PR description. -->
