### PR TITLE
chore(ci): wire krill-oss into the release-train

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ name: build
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, agents]
   # Lets you re-run the matrix from the Actions tab without a code change.
   workflow_dispatch:
 
@@ -108,3 +108,51 @@ jobs:
       # `:krill-pi4j-service` (JDK 25 daemon). Foojay auto-provisions the
       # client toolchain off the JDK 25 launcher.
       - run: ./gradlew build --no-daemon --stacktrace
+
+  # ── Release-train CI gate ──────────────────────────────────────────────
+  # Two contexts are marked *required* on the `agents` branch protection:
+  # `lessons-check` and `required-checks-passed`. The aggregator tolerates
+  # *skipped* path-filtered builds (a docs-only PR runs none) but fails on a
+  # real failure — never mark an individual conditional build job as required.
+  lessons-check:
+    name: lessons-check
+    # Exempt the permanent integration PR (agents->main): it is an aggregate of
+    # already-lessoned PRs, not a unit of work. The required-checks-passed
+    # aggregator tolerates this skip, so the integration PR still gets the build
+    # gate without a spurious lessons failure.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.ref != 'agents'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Require a lessons entry or explicit waiver
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" || true)"
+          if echo "$changed" | grep -qE '^docs/lessons/.+\.md$'; then
+            echo "lessons entry present"; exit 0
+          fi
+          if printf '%s' "$PR_BODY" | grep -qiF 'no-lesson-needed'; then
+            echo "explicit no-lesson-needed waiver in PR body"; exit 0
+          fi
+          echo "::error::PR must add a docs/lessons/YYYY-MM-DD-<slug>.md entry, or include 'no-lesson-needed' with justification in the PR body."
+          exit 1
+
+  required-checks-passed:
+    name: required-checks-passed
+    if: always() && github.event_name == 'pull_request'
+    needs: [changes, krill-sdk, krill-mcp, krill-pi4j, lessons-check]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any needed job failed or was cancelled
+        run: |
+          set -euo pipefail
+          results='${{ toJSON(needs) }}'
+          echo "$results"
+          bad="$(echo "$results" | python3 -c "import json,sys; d=json.load(sys.stdin); print('\n'.join(k for k,v in d.items() if v['result'] in ('failure','cancelled')))")"
+          if [ -n "$bad" ]; then echo "::error::failing/cancelled jobs: $bad"; exit 1; fi
+          echo "all required checks passed (skipped jobs allowed)"

--- a/.github/workflows/hotfix-cherrypick.yml
+++ b/.github/workflows/hotfix-cherrypick.yml
@@ -20,7 +20,8 @@ jobs:
     name: cherry-pick hotfix to agents
     if: >-
       github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'hotfix')
+      (contains(github.event.pull_request.labels.*.name, 'hotfix') ||
+       contains(github.event.pull_request.labels.*.name, 'hotfix:'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/hotfix-cherrypick.yml
+++ b/.github/workflows/hotfix-cherrypick.yml
@@ -1,0 +1,53 @@
+name: Hotfix Cherry-Pick
+
+# A hotfix ships straight to `main` (labeled `hotfix:`, merged by Ben). This
+# workflow then cherry-picks the merge into `agents` so the fix isn't clobbered
+# by the next integration merge. `agents` is PR-only, so the cherry-pick always
+# lands via a PR + automerge (never a direct push); on conflict it opens the PR
+# with conflict markers for a human to resolve. See kraken/docs/agent-workflow.md.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cherrypick:
+    name: cherry-pick hotfix to agents
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'hotfix')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.KRILL_KRAKEN_BOT_PAT }}
+      - name: Cherry-pick the merge commit onto a PR branch off agents
+        env:
+          GH_TOKEN: ${{ secrets.KRILL_KRAKEN_BOT_PAT }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git config user.name  krill-kraken-bot
+          git config user.email kraken@krill.zone
+          git fetch origin agents main
+          br="hotfix-cherrypick/$PR"
+          git checkout -B "$br" origin/agents
+          if git cherry-pick -m 1 "$MERGE_SHA"; then
+            body="Automated cherry-pick of hotfix #$PR onto agents. no-lesson-needed (lesson already in #$PR)."
+          else
+            git add -A
+            git commit -m "chore: cherry-pick hotfix #$PR (CONFLICTS — resolve)" || true
+            body="Automated cherry-pick of hotfix #$PR CONFLICTED. Resolve the markers and merge. no-lesson-needed (lesson already in #$PR)."
+          fi
+          git push origin "$br"
+          gh pr create --base agents --head "$br" \
+            --title "Cherry-pick hotfix #$PR to agents" \
+            --body "$body" --label risk:trivial
+          gh pr merge --auto --squash --delete-branch || true

--- a/.github/workflows/pr-risk-classify.yml
+++ b/.github/workflows/pr-risk-classify.yml
@@ -1,0 +1,47 @@
+name: PR Risk Classify
+
+# Kraken's second opinion on a PR's `risk:` label. On PRs to `agents`, Kraken's
+# classifier (kraken/scripts/release/classify-pr-risk.py) reads the diff + body
+# (+ optional corpus context) on the local model and, only if it disagrees with
+# Blue by MORE THAN ONE level, comments with its rationale and relabels. A
+# one-level disagreement is left alone. On any model/parse failure it exits
+# without overriding — it never blocks a PR. See kraken/docs/agent-workflow.md.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [agents]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: pr-risk-classify-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    name: Kraken risk second-opinion
+    runs-on: [self-hosted, Linux, X64, kraken]
+    env:
+      KRAKEN_DIR:        /home/ben/Code/kraken
+      KRILL_AGENTS_ROOT: /home/ben/Code/krill-agents
+    steps:
+      - name: Sync kraken working copy (release scripts live there)
+        run: |
+          set -euo pipefail
+          # shellcheck source=/dev/null
+          source "$KRILL_AGENTS_ROOT/scripts/lib.sh"
+          update_repo "$KRAKEN_DIR"
+      - name: Classify
+        env:
+          GH_TOKEN: ${{ secrets.KRILL_KRAKEN_BOT_PAT }}
+        run: |
+          set -euo pipefail
+          cd "$KRAKEN_DIR/scripts/release"
+          uv sync --quiet
+          uv run python classify-pr-risk.py \
+            --repo "${{ github.event.repository.name }}" \
+            --pr "${{ github.event.pull_request.number }}"

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,86 @@
+name: Release Notes
+
+# Fires when Ben merges the permanent integration PR (`agents` → `main`). Appends
+# the integration-PR narrative to docs/releases.md (on `agents`, via a PR +
+# automerge — `agents` is PR-only) and creates the release tag on the merge commit
+# (krill → vX.Y.Z from version.txt; others → release-YYYY-MM-DD). Tagging is
+# idempotent-guarded. See kraken/docs/agent-workflow.md and
+# kraken/scripts/release/generate-release-notes.py.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-notes-${{ github.event.repository.name }}
+  cancel-in-progress: false
+
+jobs:
+  notes:
+    name: append release notes + tag
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'agents'
+    runs-on: [self-hosted, Linux, X64, kraken]
+    env:
+      KRAKEN_DIR:        /home/ben/Code/kraken
+      KRILL_AGENTS_ROOT: /home/ben/Code/krill-agents
+    steps:
+      - name: Generate notes on agents, tag main
+        env:
+          GH_TOKEN: ${{ secrets.KRILL_KRAKEN_BOT_PAT }}
+          PR: ${{ github.event.pull_request.number }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          # shellcheck source=/dev/null
+          source "$KRILL_AGENTS_ROOT/scripts/lib.sh"
+          update_repo "$KRAKEN_DIR"
+
+          repo_dir="/home/ben/Code/$REPO"
+          git -C "$repo_dir" fetch --quiet origin agents main
+          git -C "$repo_dir" config user.name  krill-kraken-bot
+          git -C "$repo_dir" config user.email kraken@krill.zone
+
+          today="$(date -u +%F)"
+          version=""
+          [ "$REPO" = krill ] && version="$(cat "$repo_dir/version.txt")"
+
+          # Check out a fresh notes branch off agents so the prepend lands on
+          # current agents content, then compute the tag + write releases.md.
+          tagbranch="release-notes-$today"
+          git -C "$repo_dir" checkout -B "$tagbranch" origin/agents
+
+          cd "$KRAKEN_DIR/scripts/release"
+          uv sync --quiet
+          tag="$(uv run python generate-release-notes.py \
+                   --repo "$REPO" --pr "$PR" --date "$today" \
+                   ${version:+--version "$version"} \
+                   --releases-file "$repo_dir/docs/releases.md")"
+
+          # Commit the notes onto agents via PR + automerge (agents is PR-only).
+          cd "$repo_dir"
+          if ! git diff --quiet -- docs/releases.md; then
+            git add docs/releases.md
+            git commit -m "docs(release): notes for $tag"
+            git push origin "$tagbranch"
+            gh pr create --base agents --head "$tagbranch" \
+              --title "Release notes $tag" \
+              --body "Mechanical release-notes append. no-lesson-needed (release automation)." \
+              --label risk:trivial
+            gh pr merge --auto --squash --delete-branch
+          else
+            echo "releases.md already current for $tag; skipping notes commit"
+          fi
+
+          # Tag the integration merge commit on main (idempotent).
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "tag $tag already exists; skipping"
+          else
+            git tag -a "$tag" -m "Release $tag" "$MERGE_SHA"
+            git push origin "$tag"
+          fi

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -42,7 +42,7 @@ jobs:
           update_repo "$KRAKEN_DIR"
 
           repo_dir="/home/ben/Code/$REPO"
-          git -C "$repo_dir" fetch --quiet origin agents main
+          git -C "$repo_dir" fetch --quiet --tags origin agents main
           git -C "$repo_dir" config user.name  krill-kraken-bot
           git -C "$repo_dir" config user.email kraken@krill.zone
 

--- a/.github/workflows/release-pr-update.yml
+++ b/.github/workflows/release-pr-update.yml
@@ -1,0 +1,45 @@
+name: Release PR Update
+
+# Regenerates the permanent `agents` → `main` integration PR description on every
+# push to `agents`. The narrative is written by Kraken's release tooling
+# (kraken/scripts/release/update-release-pr.py) on the self-hosted kraken runner,
+# using the local model (no Anthropic spend) with a deterministic fallback so a
+# model hiccup never blocks the update. See kraken/docs/agent-workflow.md.
+
+on:
+  push:
+    branches: [agents]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: release-pr-update
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: regenerate integration PR description
+    runs-on: [self-hosted, Linux, X64, kraken]
+    env:
+      KRAKEN_DIR:        /home/ben/Code/kraken
+      KRILL_AGENTS_ROOT: /home/ben/Code/krill-agents
+    steps:
+      - name: Sync kraken working copy (release scripts live there)
+        run: |
+          set -euo pipefail
+          # shellcheck source=/dev/null
+          source "$KRILL_AGENTS_ROOT/scripts/lib.sh"
+          update_repo "$KRAKEN_DIR"
+          echo "kraken @ $(git -C "$KRAKEN_DIR" rev-parse --short HEAD)"
+      - name: Regenerate integration PR body
+        env:
+          GH_TOKEN: ${{ secrets.KRILL_KRAKEN_BOT_PAT }}
+        run: |
+          set -euo pipefail
+          cd "$KRAKEN_DIR/scripts/release"
+          uv sync --quiet
+          uv run python update-release-pr.py --repo "${{ github.event.repository.name }}"

--- a/docs/lessons/2026-06-27-release-train-ci-gate.md
+++ b/docs/lessons/2026-06-27-release-train-ci-gate.md
@@ -1,0 +1,37 @@
+# Release-train CI gate: aggregate, don't require conditional jobs
+
+**Root cause category:** CI/CD design — branch protection on conditional, path-filtered build jobs
+**Module:** repo plumbing (CI), `build.yml`
+
+## What happened
+
+The Krill agent fleet is moving to a release-train model: agents merge to a
+long-lived `agents` branch with automerge-on-green, and Ben merges a permanent
+`agents` → `main` integration PR to ship (see kraken `docs/agent-workflow.md`).
+Automerge needs a meaningful "green" to gate on, but `krill-oss`'s `build.yml`
+runs three **path-filtered** jobs (`krill-sdk` / `krill-mcp` / `krill-pi4j`)
+that are *skipped* on a PR that doesn't touch their tree. Marking those jobs
+directly as required status checks would deadlock any PR that legitimately
+skips one (GitHub treats a never-reported required check as pending forever).
+There was also no CI enforcement of the long-standing "every change needs a
+`docs/lessons/` entry" rule.
+
+## Fix
+
+- Added a **`required-checks-passed`** aggregator job (`always()`, depends on
+  the build jobs + `lessons-check`) that treats **skipped** as acceptable but
+  **failure/cancelled** as fatal. This single job is the only required context.
+- Added a **`lessons-check`** job that passes if the PR adds/modifies a
+  `docs/lessons/*.md` file or the PR body contains `no-lesson-needed`.
+- Widened the `push` trigger to `[main, agents]` so pushes to `agents` build.
+- Branch protection (`kraken/scripts/github/branch-protection.json`) requires
+  exactly `required-checks-passed` + `lessons-check` on `agents`.
+
+## Prevention
+
+- **Never mark a conditional/path-filtered job as a required status check.**
+  Gate on an `always()` aggregator that tolerates `skipped` and fails only on
+  `failure`/`cancelled`. The aggregator is the contract; the individual jobs
+  are implementation detail.
+- Keep required-check **context names** (the job `name:`) in lockstep with the
+  `contexts` array in `branch-protection.json` — a typo silently never-gates.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,7 @@
+# Release history
+
+Narrative release notes, newest first. Each entry is the integration-PR
+description Kraken maintained for that batch, appended automatically on merge
+to `main`. See kraken `docs/agent-workflow.md`.
+
+---


### PR DESCRIPTION
## Summary

Wires **krill-oss** into the release-train model (see `kraken/docs/agent-workflow.md`).
This is CI/automation plumbing only — no runtime code changes.

### What's added
- **CI gate** in `build.yml`: `lessons-check` + an `always()` `required-checks-passed`
  aggregator that tolerates *skipped* path-filtered builds but fails on real
  failures. These two are the contexts branch protection requires on `agents`.
  The integration PR (`agents`→`main`) is exempt from `lessons-check`.
- **`release-pr-update.yml`** — regenerates the permanent `agents`→`main`
  integration PR body on every push to `agents` (kraken runner).
- **`pr-risk-classify.yml`** — Kraken's risk second-opinion on PRs to `agents`.
- **`release-notes.yml`** — on integration-PR merge, appends `docs/releases.md`
  and tags (`release-YYYY-MM-DD`).
- **`hotfix-cherrypick.yml`** — cherry-picks `hotfix:` merges back onto `agents`.
- Seeds `docs/releases.md`.

### Test plan
- All workflow YAML validated locally (`yaml.safe_load`).
- `update-release-pr.py --repo krill-oss --dry-run` exits 0 ("no open integration PR").
- The new `lessons-check` / `required-checks-passed` jobs self-test on this PR.
- No runtime change — Ghost verify not needed.

### Notes
- Requires the `KRILL_KRAKEN_BOT_PAT` Actions secret (Contents/PRs/Issues RW).
- Part of the release-train cutover; branch protection requiring these contexts
  is applied separately after this merges.