### PR TITLE
fix(ci): source kraken runner PAT instead of a missing secret

### DIFF
--- a/.github/workflows/hotfix-cherrypick.yml
+++ b/.github/workflows/hotfix-cherrypick.yml
@@ -22,21 +22,25 @@ jobs:
       github.event.pull_request.merged == true &&
       (contains(github.event.pull_request.labels.*.name, 'hotfix') ||
        contains(github.event.pull_request.labels.*.name, 'hotfix:'))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, kraken]
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.KRILL_KRAKEN_BOT_PAT }}
       - name: Cherry-pick the merge commit onto a PR branch off agents
         env:
-          GH_TOKEN: ${{ secrets.KRILL_KRAKEN_BOT_PAT }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
+          # gh + git push authenticate from the runner's GH_TOKEN (krill-kraken-bot
+          # PAT in /etc/environment) — NOT an Actions secret. Point origin at a
+          # token https remote so the push triggers the agents PR's CI (a
+          # GITHUB_TOKEN push would not, stalling automerge).
+          set -a; source /etc/environment 2>/dev/null || true; set +a
           git config user.name  krill-kraken-bot
           git config user.email kraken@krill.zone
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git fetch origin agents main
           br="hotfix-cherrypick/$PR"
           git checkout -B "$br" origin/agents

--- a/.github/workflows/pr-risk-classify.yml
+++ b/.github/workflows/pr-risk-classify.yml
@@ -36,10 +36,11 @@ jobs:
           source "$KRILL_AGENTS_ROOT/scripts/lib.sh"
           update_repo "$KRAKEN_DIR"
       - name: Classify
-        env:
-          GH_TOKEN: ${{ secrets.KRILL_KRAKEN_BOT_PAT }}
         run: |
           set -euo pipefail
+          # gh authenticates from the runner's GH_TOKEN (krill-kraken-bot PAT in
+          # /etc/environment), like Nightly Bug Hunt — NOT an Actions secret.
+          set -a; source /etc/environment 2>/dev/null || true; set +a
           cd "$KRAKEN_DIR/scripts/release"
           uv sync --quiet
           uv run python classify-pr-risk.py \

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -31,12 +31,14 @@ jobs:
     steps:
       - name: Generate notes on agents, tag main
         env:
-          GH_TOKEN: ${{ secrets.KRILL_KRAKEN_BOT_PAT }}
           PR: ${{ github.event.pull_request.number }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           REPO: ${{ github.event.repository.name }}
         run: |
           set -euo pipefail
+          # gh + git push authenticate from the runner's GH_TOKEN (krill-kraken-bot
+          # PAT in /etc/environment), like Nightly UX Audit — NOT an Actions secret.
+          set -a; source /etc/environment 2>/dev/null || true; set +a
           # shellcheck source=/dev/null
           source "$KRILL_AGENTS_ROOT/scripts/lib.sh"
           update_repo "$KRAKEN_DIR"

--- a/.github/workflows/release-pr-update.yml
+++ b/.github/workflows/release-pr-update.yml
@@ -36,10 +36,11 @@ jobs:
           update_repo "$KRAKEN_DIR"
           echo "kraken @ $(git -C "$KRAKEN_DIR" rev-parse --short HEAD)"
       - name: Regenerate integration PR body
-        env:
-          GH_TOKEN: ${{ secrets.KRILL_KRAKEN_BOT_PAT }}
         run: |
           set -euo pipefail
+          # gh authenticates from the runner's GH_TOKEN (krill-kraken-bot PAT in
+          # /etc/environment), like Nightly Bug Hunt — NOT an Actions secret.
+          set -a; source /etc/environment 2>/dev/null || true; set +a
           cd "$KRAKEN_DIR/scripts/release"
           uv sync --quiet
           uv run python update-release-pr.py --repo "${{ github.event.repository.name }}"

--- a/docs/lessons/2026-06-27-release-train-runner-token.md
+++ b/docs/lessons/2026-06-27-release-train-runner-token.md
@@ -1,0 +1,36 @@
+# Release-train workflows: source the runner PAT, don't expect a secret
+
+**Root cause category:** CI/CD — wrong token source for self-hosted kraken-runner jobs
+**Module:** repo plumbing (CI)
+
+## What happened
+
+The release-train workflows (`release-pr-update`, `pr-risk-classify`,
+`release-notes`, `hotfix-cherrypick`) were authored with
+`env: GH_TOKEN: ${{ secrets.KRILL_KRAKEN_BOT_PAT }}`. That secret does **not
+exist** — the self-hosted kraken/blue/ghost runners get `krill-kraken-bot`'s PAT
+from **`/etc/environment`**, the same way Nightly Bug Hunt / Dev Agent Blue /
+Nightly UX Audit do. The empty secret expression resolved to an empty string and
+*shadowed* the inherited `GH_TOKEN`, so `gh` failed (`set the GH_TOKEN
+environment variable`) and `update-release-pr.py` logged "no open integration PR"
+and made no change — the integration PR body never regenerated.
+
+## Fix
+
+- Removed every `secrets.KRILL_KRAKEN_BOT_PAT` reference.
+- Each `gh`/`git push` step now does `set -a; source /etc/environment 2>/dev/null
+  || true; set +a` so the runner's `GH_TOKEN` (the bot PAT) is exported to `gh`
+  and `uv run python` subprocesses.
+- `hotfix-cherrypick` moved from `ubuntu-latest` to the kraken runner and points
+  `origin` at a token https remote, so the cherry-pick PR's push triggers CI (a
+  default `GITHUB_TOKEN` push would not, stalling automerge).
+
+## Prevention
+
+- Self-hosted-runner jobs authenticate `gh`/`git` from `/etc/environment`
+  (`krill-kraken-bot` PAT), never from an Actions secret. Copy the Nightly Bug
+  Hunt idiom, don't invent a secret name.
+- Setting `env: GH_TOKEN: ${{ secrets.MISSING }}` is worse than setting nothing —
+  it overrides the inherited value with empty. Omit it, or source the real one.
+- A PAT (not `GITHUB_TOKEN`) is required wherever a push must trigger downstream
+  workflows (CI on a bot-opened PR, the `assigned` event for Blue).


### PR DESCRIPTION
The release-train workflows referenced `secrets.KRILL_KRAKEN_BOT_PAT` (nonexistent) — self-hosted runners get the bot PAT from `/etc/environment`. The empty secret shadowed the inherited `GH_TOKEN`, so the integration-PR regeneration logged "no open integration PR" and did nothing. Now each step sources `/etc/environment`; `hotfix-cherrypick` runs on the kraken runner with a token remote. risk:trivial.