### PR TITLE
fix(ci): release-notes version from merge commit (parity)

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -50,7 +50,9 @@ jobs:
 
           today="$(date -u +%F)"
           version=""
-          [ "$REPO" = krill ] && version="$(cat "$repo_dir/version.txt")"
+          # Read the SHIPPED version from the integration merge commit, not the
+          # (possibly stale) working-copy checkout.
+          [ "$REPO" = krill ] && version="$(git -C "$repo_dir" show "$MERGE_SHA:version.txt" 2>/dev/null | tr -d '[:space:]')"
 
           # Check out a fresh notes branch off agents so the prepend lands on
           # current agents content, then compute the tag + write releases.md.


### PR DESCRIPTION
Parity with krill's release-notes version-read fix; keeps the repo-generic file identical. risk:trivial. no-lesson-needed.