### PR TITLE
removed local properties

### DIFF
--- a/krill-sdk/local.properties
+++ b/krill-sdk/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Fri May 22 08:19:36 EDT 2026
-sdk.dir=/home/ben/sdk

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/camera/CameraMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/project/camera/CameraMetaData.kt
@@ -35,7 +35,7 @@ data class CameraMetaData(
     override val snapshot: Snapshot = Snapshot(),
     override val invocationTriggers: List<InvocationTrigger> = emptyList(),
     override val nodeAction: NodeAction = NodeAction.EXECUTE,
-override val inputs: List<NodeIdentity> = emptyList(),
+    override val inputs: List<NodeIdentity> = emptyList(),
 ) : SourceMetaData {
     override fun withError(error: String) = copy(error = error)
     override fun displayName() = name.ifEmpty { "Camera" }


### PR DESCRIPTION
<!--
PR template for Sautner-Studio-LLC/krill-oss. The dev agent's CLAUDE.md mandates
this shape — keep all four sections, even if a section is one line.

`Closes #<n>` is mandatory. CI rejects PRs without a lesson entry under
`docs/lessons/YYYY-MM-DD-<slug>.md`.
-->

## Summary

<!-- 1–3 sentences. What changed and why, from the user's POV. Avoid restating the issue title. -->

## Approach

<!-- The how. Bullet the file-level changes; pick option-vs-option if you considered alternatives. Include any cross-repo escalation (filed Sautner-Studio-LLC/krill#<m>?). -->

## Introducing commit

<!-- `git log -S '<symbol>'` result that introduced the bug, plus a one-line summary. If genuinely cannot find one (e.g. predates this repo's history), say "predates split from Sautner-Studio-LLC/krill" and link the QA issue's evidence. -->

## Test plan

<!-- Checkboxes the reviewer can run. Include the gradle command, a single-test selector if relevant, and any out-of-CI verification (live swarm probe, Maven local install, etc.). -->

- [ ] `./gradlew ...`
- [ ] <regression test the QA agent should reproduce on a live swarm>

Closes #<issue>

<!-- Add `@qa-agent please verify` as a separate comment after the PR opens, not inline here — it's a request to act, not part of the PR description. -->
