### PR TITLE
feat(krill-sdk): add ServerMetaData.demoMode capability flag

### DIFF
--- a/docs/lessons/2026-07-20-servermetadata-demomode-flag.md
+++ b/docs/lessons/2026-07-20-servermetadata-demomode-flag.md
@@ -1,0 +1,50 @@
+---
+issue: Sautner-Studio-LLC/krill-oss#208
+pr: Sautner-Studio-LLC/krill-oss#NN
+date: 2026-07-20
+module: krill-sdk
+category: api-design
+---
+
+## What happened
+
+The `krill` server gained a public read-only **demo mode**
+(Sautner-Studio-LLC/krill#915) so it can be exposed safely at
+`live.krillswarm.com`. When enabled, the server hard-blocks all mutations,
+opens reads without a PIN, and redacts secrets. But clients had no way to *know*
+they were talking to a demo host — the Compose/WASM client needs that signal to
+skip FTUE/PIN onboarding and hide edit affordances (Save/Add/Delete).
+
+`ServerMetaData` (returned by `nodeHttp.readHealth()` / `GET /health`) is the
+canonical channel for a server to advertise capabilities to every client — it
+already carries `loggingEnabled` and `beaconsEnabled` booleans — but it lived in
+`krill-sdk` and had no demo flag.
+
+## Fix
+
+Added `demoMode: Boolean = false` to `ServerMetaData`
+(`krill-sdk/src/commonMain/.../krillapp/server/ServerMetaData.kt`), mirroring the
+existing capability-boolean pattern, and bumped `krill-sdk` `0.0.59 → 0.0.60`
+per the SDK versioning rule. Regression test
+`ServerMetaDataDemoModeTest` covers the default, a JSON round-trip, and
+back-compat (old payloads without the field deserialize to `false`).
+
+Downstream (separate PRs, gated on this artifact publishing to Maven Central):
+- `krill` server populates `ServerMetaData.demoMode` in
+  `ServerIdentity.serverMetaData()`.
+- `krill` client (`composeApp`) reads it on connect to drive FTUE-skip + edit
+  gating.
+
+## Prevention
+
+- **Advertise server capabilities through the one typed health payload, not
+  ad-hoc side channels.** `ServerMetaData` already had the pattern
+  (`loggingEnabled`); a new boolean field is backward-compatible because
+  `fastJson` ignores unknown keys and the default covers old servers — so a new
+  client against an old server, and an old client against a new server, both
+  work. (The server side added a stopgap unauthenticated `GET /demo` endpoint to
+  unblock itself before this artifact ships; that can be retired once every
+  client reads `ServerMetaData.demoMode`.)
+- **Bump the `krill-sdk` patch in the same PR that touches `krill-sdk/**`** —
+  CI dispatches the Maven publish on the version change; skipping it silently
+  leaves the field out of Maven Central while the build still passes.

--- a/docs/lessons/2026-07-20-servermetadata-demomode-flag.md
+++ b/docs/lessons/2026-07-20-servermetadata-demomode-flag.md
@@ -1,6 +1,6 @@
 ---
 issue: Sautner-Studio-LLC/krill-oss#208
-pr: Sautner-Studio-LLC/krill-oss#NN
+pr: Sautner-Studio-LLC/krill-oss#209
 date: 2026-07-20
 module: krill-sdk
 category: api-design

--- a/krill-sdk/build.gradle.kts
+++ b/krill-sdk/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "com.krillforge"
-version = "0.0.59"
+version = "0.0.60"
 
 kotlin {
     jvmToolchain(21)

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/ServerMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/server/ServerMetaData.kt
@@ -57,6 +57,17 @@ data class ServerMetaData(
 
     val beaconsEnabled: Boolean = true,
 
+    /**
+     * `true` when the server is running as a public **read-only demo** (the
+     * `demoMode` flag in the server's `/etc/krill/config.json`). Clients read
+     * this to skip FTUE/PIN onboarding and hide edit affordances
+     * (Save/Add/Delete). The server itself hard-blocks every mutation
+     * server-side regardless of this flag, so it is a UX hint, not the
+     * enforcement boundary. Defaults to `false`; old records lacking the key
+     * deserialize fine (`fastJson` ignores unknown keys).
+     */
+    val demoMode: Boolean = false,
+
     override val error: String = "",
     override val sources: List<NodeIdentity> = emptyList(),
     override val snapshot: Snapshot = Snapshot(),

--- a/krill-sdk/src/commonTest/kotlin/krill/zone/shared/krillapp/server/ServerMetaDataDemoModeTest.kt
+++ b/krill-sdk/src/commonTest/kotlin/krill/zone/shared/krillapp/server/ServerMetaDataDemoModeTest.kt
@@ -1,0 +1,58 @@
+package krill.zone.shared.krillapp.server
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for the `ServerMetaData.demoMode` capability flag
+ * (krill-oss#208 — lets clients detect a read-only public demo server so they
+ * can skip FTUE and hide edit affordances).
+ *
+ * Covers:
+ *  - the flag defaults to `false` (a normal server);
+ *  - it round-trips through JSON;
+ *  - old wire payloads that predate the field still deserialize (defaulting to
+ *    `false`), so a new client talking to an old server is unaffected.
+ */
+class ServerMetaDataDemoModeTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `demoMode defaults to false`() {
+        assertFalse(ServerMetaData().demoMode)
+    }
+
+    @Test
+    fun `demoMode round-trips through JSON`() {
+        val encoded = json.encodeToString(ServerMetaData.serializer(), ServerMetaData(demoMode = true))
+        assertTrue(encoded.contains("\"demoMode\":true"))
+        val decoded = json.decodeFromString(ServerMetaData.serializer(), encoded)
+        assertTrue(decoded.demoMode)
+    }
+
+    @Test
+    fun `payload without demoMode deserializes with false default`() {
+        val oldPayload = """
+            {
+              "name": "example-host",
+              "port": 8442,
+              "version": "1.0.0",
+              "loggingEnabled": false,
+              "beaconsEnabled": true,
+              "error": "",
+              "sources": [],
+              "snapshot": {"timestamp": 0, "value": ""},
+              "invocationTriggers": [],
+              "nodeAction": "EXECUTE",
+              "inputs": []
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString(ServerMetaData.serializer(), oldPayload)
+        assertFalse(decoded.demoMode)
+        assertEquals("example-host", decoded.name)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `demoMode: Boolean = false` field to `ServerMetaData` so clients can
detect a public **read-only demo** server (the server-side feature in
Sautner-Studio-LLC/krill#915) and skip FTUE/PIN onboarding + hide edit
affordances. Bumps `krill-sdk` `0.0.59 → 0.0.60` so the field publishes to
Maven Central.

## Approach

- `krill-sdk/src/commonMain/.../krillapp/server/ServerMetaData.kt` — new
  `demoMode` boolean beside the existing capability booleans
  (`loggingEnabled`, `beaconsEnabled`). Backward-compatible: default `false`,
  and `fastJson`'s `ignoreUnknownKeys` means old servers (no field) and old
  clients (ignore the field) both keep working.
- `krill-sdk/build.gradle.kts` — version bump per the SDK versioning rule (CI
  dispatches the Maven publish on the change).
- Downstream, gated on this artifact publishing (separate PRs):
  `krill` server populates the flag in `ServerIdentity.serverMetaData()`; the
  `krill` client reads it to drive FTUE-skip + edit gating. The server side
  currently advertises demo status via a stopgap unauthenticated `GET /demo`
  endpoint (krill#915) until every client reads this field.

## Introducing commit

Not a bug — new capability field. Predates nothing; `ServerMetaData` simply had
no demo signal.

## Test plan

- [x] `cd krill-sdk && ./gradlew jvmTest --tests "*ServerMetaDataDemoModeTest"` — default is false, JSON round-trip preserves it, old payloads without the field deserialize to false.
- [ ] `cd krill-sdk && ./gradlew check` (full SDK suite) in CI.

Closes #208