### PR TITLE
fix(krill-sdk): default new Calculation node name to "Calculation" not "Companion"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ krill-lambda-sdk/*.iml
 !krill-sdk/gradle/wrapper/gradle-wrapper.jar
 .idea/
 .idea/**
+krill-sdk/local.properties

--- a/docs/lessons/2026-07-21-calculation-default-name-companion.md
+++ b/docs/lessons/2026-07-21-calculation-default-name-companion.md
@@ -59,8 +59,8 @@ place the bug lived.
   machinery.
 - `krill-sdk/.../node/NodeMetaDataInterfaceTest.kt` — added a regression that asserts the
   **default**: `CalculationEngineNodeMetaData().displayName() == "Calculation"`.
-- Bumped `krill-sdk` `0.0.59 → 0.0.60` so CI republishes to Maven Central; the app picks up the
-  fix once `krill`'s `krill-sdk` pin is bumped to `0.0.60`.
+- Bumped `krill-sdk` `0.0.60 → 0.0.61` so CI republishes to Maven Central; the app picks up the
+  fix once `krill`'s `krill-sdk` pin is bumped to `0.0.61`.
 - Deliberately did **not** rename the class to `CalculationMetaData` (an in-progress rename was
   reverted): it has no `@SerialName`, so its polymorphic discriminator is its fully-qualified
   name — renaming would break deserialization of already-persisted Calculation nodes and break

--- a/docs/lessons/2026-07-21-calculation-default-name-companion.md
+++ b/docs/lessons/2026-07-21-calculation-default-name-companion.md
@@ -1,0 +1,83 @@
+---
+issue: Sautner-Studio-LLC/krill-oss#210
+pr: Sautner-Studio-LLC/krill-oss#PENDING
+date: 2026-07-21
+module: krill-sdk
+category: serialization
+---
+
+## What happened
+
+Every brand-new `Calculation` node created from the app was labelled **`Companion`**
+instead of `Calculation`. The label is `node.name()` → `meta.displayName()` → the meta's
+`name` field, and `CalculationEngineNodeMetaData` declared its default as:
+
+```kotlin
+@Serializable
+data class CalculationEngineNodeMetaData(
+    ...
+    val name: String = this::class.simpleName!!,   // intended: "CalculationEngineNodeMetaData"
+    ...
+)
+```
+
+The creation path is `KrillApp.meta()` in the `krill` repo, whose Calculation arm calls
+`CalculationEngineNodeMetaData()` with no arguments — so `name` always took its default.
+
+## Root cause
+
+`this::class.simpleName` does **not** resolve to the data class inside a `@Serializable`
+primary-constructor default value. Because the class is `@Serializable`, kotlinx.serialization
+generates a `Companion` object (holding the serializer), and the compiler lowers the
+default-value initializer into a synthetic context associated with that `Companion`. `this`
+there is the `Companion` object, so `this::class.simpleName` evaluates to the literal string
+`"Companion"`.
+
+Nothing failed — `"Companion"` is a perfectly valid `String`, it serialized, persisted, and
+rendered as a legitimate-looking (wrong) label. This was the *only* class in the SDK using
+`this::class.simpleName` as a default value (`grep` confirms), so the blast radius was exactly
+one node type.
+
+The neighbouring bug fixed in #197 (`displayName()` made abstract, `override fun displayName() =
+name` added to twelve metas — including this one) is what made the wrong `name` *visible*:
+before that, `displayName()` returned `""` and the type string was shown instead, masking the
+bad default. Fixing the display path uncovered that the stored value itself was wrong.
+
+The pre-existing regression test never protected this:
+
+```kotlin
+assertEquals("Average", CalculationEngineNodeMetaData(name = "Average").displayName())
+```
+
+It passes an explicit `name`, so it exercises `displayName()` but never the *default* — the only
+place the bug lived.
+
+## Fix
+
+- `krill-sdk/.../calculation/CalculationEngineNodeMetaData.kt` — default is now the literal
+  `val name: String = "Calculation"`. Independent of the class name and of the serialization
+  machinery.
+- `krill-sdk/.../node/NodeMetaDataInterfaceTest.kt` — added a regression that asserts the
+  **default**: `CalculationEngineNodeMetaData().displayName() == "Calculation"`.
+- Bumped `krill-sdk` `0.0.59 → 0.0.60` so CI republishes to Maven Central; the app picks up the
+  fix once `krill`'s `krill-sdk` pin is bumped to `0.0.60`.
+- Deliberately did **not** rename the class to `CalculationMetaData` (an in-progress rename was
+  reverted): it has no `@SerialName`, so its polymorphic discriminator is its fully-qualified
+  name — renaming would break deserialization of already-persisted Calculation nodes and break
+  the `krill` build, none of which is needed to fix the label.
+
+## Prevention
+
+- **`this::class` in a `@Serializable` constructor default resolves to `Companion`, not the
+  data class.** Never derive a default field value from `this::class.simpleName` on a
+  `@Serializable` type. Use a literal, or compute the name at the call site with an explicit
+  class reference (`Foo::class.simpleName`, as `KrillAppMeta` already does for `CronTimer`/`Timer`).
+- **Test the default, not just the explicit value.** A `displayName()` test that always passes an
+  explicit `name` can never catch a wrong default. When a field has a meaningful default, assert
+  the zero-arg construction path directly.
+- **A wrong-but-plausible value hides longer than a crash.** `"Companion"` is a valid string that
+  serialized and rendered fine; only a human reading the canvas caught it. Prefer defaults that
+  are either obviously correct or loudly absent over ones that merely look like data.
+- **A serial discriminator is a wire contract.** Renaming a `@Serializable` polymorphic subtype
+  without a `@SerialName` pin silently changes its on-the-wire type tag and breaks every payload
+  already persisted under the old name — keep renames and behaviour fixes separate.

--- a/docs/lessons/2026-07-21-calculation-default-name-companion.md
+++ b/docs/lessons/2026-07-21-calculation-default-name-companion.md
@@ -1,6 +1,6 @@
 ---
 issue: Sautner-Studio-LLC/krill-oss#210
-pr: Sautner-Studio-LLC/krill-oss#PENDING
+pr: Sautner-Studio-LLC/krill-oss#212
 date: 2026-07-21
 module: krill-sdk
 category: serialization

--- a/krill-sdk/build.gradle.kts
+++ b/krill-sdk/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "com.krillforge"
-version = "0.0.60"
+version = "0.0.61"
 
 kotlin {
     jvmToolchain(21)

--- a/krill-sdk/build.gradle.kts
+++ b/krill-sdk/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "com.krillforge"
-version = "0.0.59"
+version = "0.0.60"
 
 kotlin {
     jvmToolchain(21)

--- a/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/calculation/CalculationEngineNodeMetaData.kt
+++ b/krill-sdk/src/commonMain/kotlin/krill/zone/shared/krillapp/executor/calculation/CalculationEngineNodeMetaData.kt
@@ -18,8 +18,17 @@ import krill.zone.shared.node.*
 data class CalculationEngineNodeMetaData(
     override val sources: List<NodeIdentity> = emptyList(),
 
-    /** Display name; defaults to the class's simple name on creation. */
-    val name: String = this::class.simpleName!!,
+    /**
+     * Display name; defaults to the literal `"Calculation"` on creation.
+     *
+     * Was previously `this::class.simpleName!!`, but because this is a
+     * `@Serializable` data class the default-value initializer is compiled into
+     * a synthetic context on the generated `Companion` — so `this::class`
+     * resolved to the `Companion` object and every brand-new Calculation node
+     * was labelled `"Companion"` instead of its type. A literal keeps the label
+     * stable and independent of the class name / serialization machinery.
+     */
+    val name: String = "Calculation",
     /** Free-form formula string evaluated by the server's calculation engine. */
     val formula: String = "",
     /**

--- a/krill-sdk/src/commonTest/kotlin/krill/zone/shared/node/NodeMetaDataInterfaceTest.kt
+++ b/krill-sdk/src/commonTest/kotlin/krill/zone/shared/node/NodeMetaDataInterfaceTest.kt
@@ -134,6 +134,19 @@ class NodeMetaDataInterfaceTest {
         assertEquals("Average", CalculationEngineNodeMetaData(name = "Average").displayName())
     }
 
+    /**
+     * Regression: a brand-new Calculation node (no explicit name) must default to
+     * "Calculation", not "Companion". The default value used to be
+     * `this::class.simpleName!!`, which — because this is a `@Serializable` data
+     * class — resolved `this` to the generated `Companion` object at construction
+     * time, so every fresh node was mislabelled "Companion". Asserting on the
+     * *default* is what guards this; the explicit-name test above never could.
+     */
+    @Test
+    fun `default displayName for CalculationEngineNodeMetaData is Calculation not Companion`() {
+        assertEquals("Calculation", CalculationEngineNodeMetaData().displayName())
+    }
+
     @Test
     fun `displayName returns name field for ButtonMetaData`() {
         assertEquals("Arm", ButtonMetaData(name = "Arm").displayName())


### PR DESCRIPTION
## Summary

Newly created `Calculation` nodes were labelled **`Companion`** on the canvas instead of `Calculation`. This fixes the default so a fresh Calculation node reads `Calculation`.

## Approach

- `krill-sdk/.../calculation/CalculationEngineNodeMetaData.kt` — the `name` default was `this::class.simpleName!!`. Because the class is `@Serializable`, the primary-constructor default-value initializer is lowered onto the generated `Companion` object, so `this::class.simpleName` resolves to the literal `"Companion"`. `KrillApp.meta()` builds `CalculationEngineNodeMetaData()` with no args, so that default always won. Replaced it with the literal `val name: String = "Calculation"`.
- `krill-sdk/.../node/NodeMetaDataInterfaceTest.kt` — added a regression asserting the **default**: `CalculationEngineNodeMetaData().displayName() == "Calculation"`. The pre-existing test passed `name` explicitly, so it could never have caught this.
- `krill-sdk/build.gradle.kts` — bumped `0.0.59 → 0.0.60` (required for any `krill-sdk/**` change; CI auto-publishes to Maven). The app picks up the fix once `krill`'s `krill-sdk` pin is bumped to `0.0.60` in a follow-up.
- **Not** renamed to `CalculationMetaData` (an in-progress rename was reverted). The class has no `@SerialName`, so its polymorphic discriminator is its FQN — renaming would break deserialization of already-persisted Calculation nodes and break the `krill` build, neither of which is needed to fix the label.

## Introducing commit

`05a6e38` — "krill sdk 0.0.9" (2026-04-25). Introduced `val name: String = this::class.simpleName!!`. The mislabel stayed masked until #197 made `displayName()` return `name` (it previously returned `""`, falling back to the type string).

## Test plan

- [x] `./gradlew :krill-sdk:jvmTest --tests "krill.zone.shared.node.NodeMetaDataInterfaceTest"` — passes, incl. the new default regression.
- Skipping `needs-qa-verify` — the SDK behavior change is not in any buildable artifact from this PR; it reaches a live swarm only after `krill` bumps its `krill-sdk` pin to 0.0.60, so Ghost's deb build could not exercise it. Covered by the SDK jvmTest regression.

Closes #210